### PR TITLE
Ansible modules for PowerFlex release version 1.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ansible-powerflex Change Log
 
+## Version 1.3.0 - released on 28/06/22
+- Added operations like Add/remove standby mdm, rename mdm, change mdm cluster ownership, switch mdm cluster mode, set performance profile, modify virtual IP interfaces and Get high level details of MDM cluster.
+- Added execution environment manifest file to support building an execution environment with ansible-builder.
+- Enabled the check_mode support for info module
+
 ## Version 1.2.0 - released on 25/03/22
 - Added CRUD operations for protection domain module.
 - Names of previously released modules have been changed from dellemc_powerflex_\<module name> to \<module name>.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 The Ansible Modules for Dell Technologies (Dell) PowerFlex allow Data Center and IT administrators to use RedHat Ansible to automate and orchestrate the provisioning and management of Dell PowerFlex storage systems.
 
-The capabilities of the Ansible modules are managing SDCs, volumes, snapshots, storage pools, SDSs, devices, protection domains, and to gather high level facts from the storage system. The options available are list, show, create, modify and delete. These tasks can be executed by running simple playbooks written in yaml syntax. The modules are written so that all the operations are idempotent, so making multiple identical requests has the same effect as making a single request.
+The capabilities of the Ansible modules are managing SDCs, volumes, snapshots, storage pools, SDSs, devices, protection domains, MDM cluster, and to gather high level facts from the storage system. The options available are list, show, create, modify and delete. These tasks can be executed by running simple playbooks written in yaml syntax. The modules are written so that all the operations are idempotent, so making multiple identical requests has the same effect as making a single request.
 
 ## License
-The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerflex/blob/1.2.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerFlex are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerflex/blob/1.2.0/MODULE-LICENSE) for the full terms.
+The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerflex/blob/1.3.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerFlex are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerflex/blob/1.3.0/MODULE-LICENSE) for the full terms.
 
 ## Support
-The Ansible collection for PowerFlex is supported by Dell and are provided under the terms of the license attached to the collection. Please see the [LICENSE](#license) section for the full terms. Dell does not provide any support for the source code modifications. For any Ansible modules issues, questions or feedback, join the [Dell Automation Community](https://www.dell.com/community/Automation/bd-p/Automation).
+The Ansible collection for PowerFlex is supported by Dell and is provided under the terms of the license attached to the collection. Please see the [LICENSE](#license) section for the full terms. Dell does not provide any support for the source code modifications. For any Ansible modules issues, questions or feedback, join the [Dell Automation Community](https://www.dell.com/community/Automation/bd-p/Automation).
 
 
 ## Prerequisites
 
-| **Ansible Modules** | **PowerFlex/VxFlex OS Version** | **Red Hat Enterprise Linux**| **SDK version**| **Python version** | **Ansible** |
-|---------------------|-----------------------|------------------------------|--------------------|--------------------|-------------|
-| v1.2.0 | 3.5, <br> 3.6 |7.9, <br>8.2, <br>8.4, <br>8.5 | 1.3.0 | 3.7.x <br> 3.8.x <br> 3.9.x <br> 3.10.x | 2.10 <br> 2.11 <br> 2.12 |
+| **Ansible Modules** | **PowerFlex/VxFlex OS Version** | **Red Hat Enterprise Linux**| **SDK version** | **Python version** | **Ansible**              |
+|---------------------|-----------------------|------------------------------|-------|--------------------|--------------------------|
+| v1.3.0 | 3.5, <br> 3.6 |7.9, <br>8.2, <br>8.4, <br>8.5 | 1.4.0 | 3.8.x <br> 3.9.x <br> 3.10.x | 2.11 <br> 2.12 <br> 2.13 |
 
   * Please follow PyPowerFlex installation instructions on [PyPowerFlex Documentation](https://github.com/dell/python-powerflex)
   
@@ -23,14 +23,15 @@ The Ansible collection for PowerFlex is supported by Dell and are provided under
 The modules are written in such a way that all requests are idempotent and hence fault-tolerant. It essentially means that the result of a successfully performed request is independent of the number of times it is executed.
 
 ## List of Ansible Modules for Dell PowerFlex
-  * [Info module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#info-module)
-  * [Snapshot module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#snapshot-module)
-  * [SDC module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#sdc-module)
-  * [Storage pool module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#storage-pool-module)
-  * [Volume module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#volume-module)
-  * [SDS module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#sds-module)
-  * [Device Module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#device-module)
-  * [Protection Domain Module](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/Product%20Guide.md#protection-domain-module)
+  * [Info module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#info-module)
+  * [Snapshot module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#snapshot-module)
+  * [SDC module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#sdc-module)
+  * [Storage pool module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#storage-pool-module)
+  * [Volume module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#volume-module)
+  * [SDS module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#sds-module)
+  * [Device Module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#device-module)
+  * [Protection Domain Module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#protection-domain-module)
+  * [MDM Cluster Module](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/Product%20Guide.md#mdm-cluster-module)
 
 ## Installation of SDK
 * Install the python SDK named [PyPowerFlex](https://pypi.org/project/PyPowerFlex/). It can be installed using pip, based on appropriate python version. Execute this command:
@@ -62,7 +63,7 @@ The modules are written in such a way that all requests are idempotent and hence
 
   * Download the latest tar build from any of the available distribution channel [Ansible Galaxy](https://galaxy.ansible.com/dellemc/powerflex) /[Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dellemc/powerflex) and use this command to install the collection anywhere in your system:
  
-        ansible-galaxy collection install dellemc-powerflex-1.2.0.tar.gz -p <install_path>
+        ansible-galaxy collection install dellemc-powerflex-1.3.0.tar.gz -p <install_path>
 
   * Set the environment variable:
   
@@ -87,7 +88,7 @@ The modules are written in such a way that all requests are idempotent and hence
         ansible-doc dellemc.powerflex.volume
 
 ## Running Ansible Modules
-The Ansible server must be configured with Python library for PowerFlex to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerflex/blob/1.2.0/docs/) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
+The Ansible server must be configured with Python library for PowerFlex to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerflex/blob/1.3.0/docs/) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
 
 ## SSL Certificate Validation
 
@@ -105,3 +106,24 @@ The Ansible server must be configured with Python library for PowerFlex to run t
 
 ## Results
 Each module returns the updated state and details of the entity, For example, if you are using the Volume module, all calls will return the updated details of the volume. Sample result is shown in each module's documentation.
+
+## Ansible Execution Environment
+Ansible can also be installed in a container environment. Ansible Builder provides the ability to create reproducible, self-contained environments as container images that can be run as Ansible execution environments.
+* Install the ansible builder package using:
+
+      pip3 install ansible-builder
+* Create the execution environment using:
+
+      ansible-builder build --tag <tag_name> --container-runtime docker
+* After the image is built, run the container using:
+
+      docker run -it <tag_name> /bin/bash
+* Verify collection installation using command:
+
+      ansible-galaxy collection list
+* The playbook can be run on the container using:
+
+      docker run --rm -v $(pwd):/runner <tag_name> ansible-playbook info_test.yml
+
+## Maintenance
+Ansible Modules for Dell Technologies PowerFlex deprecation cycle is aligned with [Ansible](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html).

--- a/docs/Product Guide.md
+++ b/docs/Product Guide.md
@@ -1,5 +1,5 @@
 # Ansible Modules for Dell Technologies PowerFlex
-## Product Guide 1.2.0
+## Product Guide 1.3.0
 © 2022 Dell Inc. or its subsidiaries. All rights reserved. Dell, and other trademarks are trademarks of Dell Inc. or its subsidiaries. Other trademarks may be trademarks of their respective owners.
 
 --------------
@@ -18,54 +18,61 @@
     *   [Examples](#examples-1)
     *   [Return Values](#return-values-1)
     *   [Authors](#authors-1)
-*   [Protection Domain Module](#protection-domain-module)
+*   [MDM Cluster Module](#mdm-cluster-module)
     *   [Synopsis](#synopsis-2)
     *   [Parameters](#parameters-2)
     *   [Notes](#notes-2)
     *   [Examples](#examples-2)
     *   [Return Values](#return-values-2)
     *   [Authors](#authors-2)
-*   [SDC Module](#sdc-module)
+*   [Protection Domain Module](#protection-domain-module)
     *   [Synopsis](#synopsis-3)
     *   [Parameters](#parameters-3)
     *   [Notes](#notes-3)
     *   [Examples](#examples-3)
     *   [Return Values](#return-values-3)
     *   [Authors](#authors-3)
-*   [SDS Module](#sds-module)
+*   [SDC Module](#sdc-module)
     *   [Synopsis](#synopsis-4)
     *   [Parameters](#parameters-4)
     *   [Notes](#notes-4)
     *   [Examples](#examples-4)
     *   [Return Values](#return-values-4)
     *   [Authors](#authors-4)
-*   [Snapshot Module](#snapshot-module)
+*   [SDS Module](#sds-module)
     *   [Synopsis](#synopsis-5)
     *   [Parameters](#parameters-5)
     *   [Notes](#notes-5)
     *   [Examples](#examples-5)
     *   [Return Values](#return-values-5)
     *   [Authors](#authors-5)
-*   [Storage Pool Module](#storage-pool-module)
+*   [Snapshot Module](#snapshot-module)
     *   [Synopsis](#synopsis-6)
     *   [Parameters](#parameters-6)
     *   [Notes](#notes-6)
     *   [Examples](#examples-6)
     *   [Return Values](#return-values-6)
     *   [Authors](#authors-6)
-*   [Volume Module](#volume-module)
+*   [Storage Pool Module](#storage-pool-module)
     *   [Synopsis](#synopsis-7)
     *   [Parameters](#parameters-7)
     *   [Notes](#notes-7)
     *   [Examples](#examples-7)
     *   [Return Values](#return-values-7)
     *   [Authors](#authors-7)
+*   [Volume Module](#volume-module)
+    *   [Synopsis](#synopsis-8)
+    *   [Parameters](#parameters-8)
+    *   [Notes](#notes-8)
+    *   [Examples](#examples-8)
+    *   [Return Values](#return-values-8)
+    *   [Authors](#authors-8)
 
 --------------
 
 # Device Module
 
-Manage device on Dell EMC PowerFlex
+Manage device on Dell PowerFlex
 
 ### Synopsis
  Managing device on PowerFlex storage system includes adding new device, getting details of device, and removing a device.
@@ -81,45 +88,13 @@ Manage device on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=1 > storage_pool_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Storage Pool ID.  <br> Used while adding a storage device.  <br> Media type supported are SSD and HDD.  <br> Mutually exclusive with storage_pool_name, acceleration_pool_id and acceleration_pool_name. </td>
-        </tr>
                     <tr>
-            <td colspan=1 > storage_pool_name</td>
+            <td colspan=1 > acceleration_pool_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Storage Pool name.  <br> Used while adding a storage device.  <br> Mutually exclusive with storage_pool_id, acceleration_pool_id and acceleration_pool_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > sds_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the SDS.  <br> Required while adding a device.  <br> Mutually exclusive with sds_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > device_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Device name.  <br> Mutually exclusive with device_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the device. </td>
+            <td> <br> Acceleration Pool Name.  <br> Used while adding an acceleration device.  <br> Media type supported are SSD and NVDIMM.  <br> Mutually exclusive with storage_pool_id, storage_pool_name and acceleration_pool_name. </td>
         </tr>
                     <tr>
             <td colspan=1 > timeout</td>
@@ -130,92 +105,28 @@ Manage device on Dell EMC PowerFlex
             <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=1 > acceleration_pool_name</td>
+            <td colspan=1 > storage_pool_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Acceleration Pool Name.  <br> Used while adding an acceleration device.  <br> Media type supported are SSD and NVDIMM.  <br> Mutually exclusive with storage_pool_id, storage_pool_name and acceleration_pool_name. </td>
+            <td> <br> Storage Pool name.  <br> Used while adding a storage device.  <br> Mutually exclusive with storage_pool_id, acceleration_pool_id and acceleration_pool_name. </td>
         </tr>
                     <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td></td>
-            <td> True </td>
-            <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > external_acceleration_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>Invalid</li>  <li>None</li>  <li>Read</li>  <li>Write</li>  <li>ReadAndWrite</li> </ul></td>
-            <td> <br> Device external acceleration types.  <br> Used while adding a device. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > current_pathname</td>
+            <td colspan=1 > acceleration_pool_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Full path of the device to be added.  <br> Required while adding a device. </td>
+            <td> <br> Acceleration Pool ID.  <br> Used while adding an acceleration device.  <br> Media type supported are SSD and NVDIMM.  <br> Mutually exclusive with acceleration_pool_name, storage_pool_name and storage_pool_id. </td>
         </tr>
                     <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > media_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>HDD</li>  <li>SSD</li>  <li>NVDIMM</li> </ul></td>
-            <td> <br> Device media types.  <br> Required while adding a device. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > device_id</td>
+            <td colspan=1 > sds_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Device ID.  <br> Mutually exclusive with device_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > protection_domain_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Protection domain ID.  <br> Used while identifying a storage pool along with storage_pool_name.  <br> Mutually exclusive with protection_domain_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > username</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > gateway_host</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+            <td> <br> The name of the SDS.  <br> Required while adding a device.  <br> Mutually exclusive with sds_id. </td>
         </tr>
                     <tr>
             <td colspan=1 > protection_domain_name</td>
@@ -226,6 +137,78 @@ Manage device on Dell EMC PowerFlex
             <td> <br> Protection domain name.  <br> Used while identifying a storage pool along with storage_pool_name.  <br> Mutually exclusive with protection_domain_id. </td>
         </tr>
                     <tr>
+            <td colspan=1 > current_pathname</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Full path of the device to be added.  <br> Required while adding a device. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > media_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>HDD</li>  <li>SSD</li>  <li>NVDIMM</li> </ul></td>
+            <td> <br> Device media types.  <br> Required while adding a device. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > username</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > device_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Device name.  <br> Mutually exclusive with device_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > gateway_host</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > protection_domain_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Protection domain ID.  <br> Used while identifying a storage pool along with storage_pool_name.  <br> Mutually exclusive with protection_domain_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the device. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > external_acceleration_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>Invalid</li>  <li>None</li>  <li>Read</li>  <li>Write</li>  <li>ReadAndWrite</li> </ul></td>
+            <td> <br> Device external acceleration types.  <br> Used while adding a device. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > sds_id</td>
             <td> str  </td>
             <td></td>
@@ -234,21 +217,45 @@ Manage device on Dell EMC PowerFlex
             <td> <br> The ID of the SDS.  <br> Required while adding a device.  <br> Mutually exclusive with sds_name. </td>
         </tr>
                     <tr>
-            <td colspan=1 > acceleration_pool_id</td>
+            <td colspan=1 > device_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Acceleration Pool ID.  <br> Used while adding an acceleration device.  <br> Media type supported are SSD and NVDIMM.  <br> Mutually exclusive with acceleration_pool_name, storage_pool_name and storage_pool_id. </td>
+            <td> <br> Device ID.  <br> Mutually exclusive with device_name. </td>
         </tr>
-                                                                    </table>
+                    <tr>
+            <td colspan=1 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > storage_pool_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Storage Pool ID.  <br> Used while adding a storage device.  <br> Media type supported are SSD and HDD.  <br> Mutually exclusive with storage_pool_name, acceleration_pool_id and acceleration_pool_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td></td>
+            <td> True </td>
+            <td></td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                                                                                            </table>
 
 ### Notes
 * The value for device_id is generated only after successful addition of the device.
 * Unique ways to identify a device - (current_pathname , sds_id) or (current_pathname , sds_name) or (device_name , sds_name) or (device_name , sds_id) or device_id.
 * It is recommended to install Rfcache driver for SSD device on SDS in order to add it to an acceleration pool.
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -326,7 +333,7 @@ Manage device on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
+                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -340,31 +347,31 @@ Manage device on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > externalAccelerationType </td>
+                <td colspan=2 > aggregatedState </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Indicates external acceleration type. </td>
+                <td> Indicates aggregated state. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > fglNvdimmMetadataAmortizationX100 </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Indicates FGL NVDIMM meta data amortization value. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > errorState </td>
+                <td colspan=2 > deviceState </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Indicates error state. </td>
+                <td> Indicates device state. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > writeCacheActive </td>
+                <td colspan=2 > rfcacheErrorDeviceDoesNotExist </td>
                 <td> bool </td>
                 <td>success</td>
-                <td> Indicates write cache active. </td>
+                <td> Indicates RF cache error device does not exist. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > accelerationProps </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates acceleration props. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -375,10 +382,66 @@ Manage device on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > deviceOriginalPathName </td>
+                <td colspan=2 > accelerationPoolId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Device original path name. </td>
+                <td> Acceleration pool ID. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > capacity </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Device capacity. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > cacheLookAheadActive </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates cache look ahead active state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > ssdEndOfLifeState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates SSD end of life state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > storagePoolId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Storage Pool ID. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > serialNumber </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates Serial number. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Device name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > errorState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates error state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > spSdsId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates SPs SDS ID. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -389,17 +452,10 @@ Manage device on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > mediaFailing </td>
-                <td> bool </td>
+                <td colspan=2 > fglNvdimmWriteCacheSize </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Indicates media failing. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > vendorName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates vendor name. </td>
+                <td> Indicates FGL NVDIMM write cache size. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -407,6 +463,13 @@ Manage device on Dell EMC PowerFlex
                 <td> str </td>
                 <td>success</td>
                 <td> Indicates persistent checksum state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > protectionDomainName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Protection domain name. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -433,206 +496,10 @@ Manage device on Dell EMC PowerFlex
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > firmwareVersion </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates firmware version. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > rfcacheProps </td>
-                <td> str </td>
-                <td>success</td>
-                <td> RF cache props. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > storagePoolId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Storage Pool ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > physicalSectorSizeInBytes </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Physical sector size in bytes. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > ledSetting </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates LED setting. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sdsName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> SDS name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > ataSecurityActive </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Indicates ATA security active state. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > spSdsId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates SPs SDS ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > deviceType </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates device type. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > maxCapacityInKb </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Maximum device capacity limit in KB. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > rfcacheErrorDeviceDoesNotExist </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Indicates RF cache error device does not exist. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > storageProps </td>
-                <td> list </td>
-                <td>success</td>
-                <td> Storage props. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > ssdEndOfLifeState </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates SSD end of life state. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > accelerationProps </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates acceleration props. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > protectionDomainId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Protection domain ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > protectionDomainName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Protection domain name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > longSuccessfulIos </td>
-                <td> list </td>
-                <td>success</td>
-                <td> Indicates long successful IOs. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > accelerationPoolName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Acceleration pool name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > fglNvdimmWriteCacheSize </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Indicates FGL NVDIMM write cache size. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > capacityLimitInKb </td>
                 <td> int </td>
                 <td>success</td>
                 <td> Device capacity limit in KB. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Device ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > autoDetectMediaType </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates auto detection of media type. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > cacheLookAheadActive </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Indicates cache look ahead active state. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > modelName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates model name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > accelerationPoolId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Acceleration pool ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > serialNumber </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Indicates Serial number. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > logicalSectorSizeInBytes </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Logical sector size in bytes. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > capacity </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Device capacity. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Device name. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -643,17 +510,38 @@ Manage device on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > deviceState </td>
+                <td colspan=2 > accelerationPoolName </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Indicates device state. </td>
+                <td> Acceleration pool name. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > storagePoolName </td>
+                <td colspan=2 > protectionDomainId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Storage Pool name. </td>
+                <td> Protection domain ID. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > ataSecurityActive </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates ATA security active state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > firmwareVersion </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates firmware version. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > longSuccessfulIos </td>
+                <td> list </td>
+                <td>success</td>
+                <td> Indicates long successful IOs. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -664,10 +552,94 @@ Manage device on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > aggregatedState </td>
+                <td colspan=2 > physicalSectorSizeInBytes </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Physical sector size in bytes. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > deviceType </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Indicates aggregated state. </td>
+                <td> Indicates device type. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > fglNvdimmMetadataAmortizationX100 </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Indicates FGL NVDIMM meta data amortization value. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > modelName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates model name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > ledSetting </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates LED setting. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > autoDetectMediaType </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates auto detection of media type. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > writeCacheActive </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates write cache active. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sdsName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> SDS name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > rfcacheProps </td>
+                <td> str </td>
+                <td>success</td>
+                <td> RF cache props. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Device ID. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > maxCapacityInKb </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Maximum device capacity limit in KB. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > vendorName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates vendor name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > storagePoolName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Storage Pool name. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -676,7 +648,42 @@ Manage device on Dell EMC PowerFlex
                 <td>success</td>
                 <td> Indicates media type. </td>
             </tr>
-                                                                                                        </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > externalAccelerationType </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates external acceleration type. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > storageProps </td>
+                <td> list </td>
+                <td>success</td>
+                <td> Storage props. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > deviceOriginalPathName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Device original path name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > logicalSectorSizeInBytes </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Logical sector size in bytes. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > mediaFailing </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates media failing. </td>
+            </tr>
+                                                                                        </table>
 
 ### Authors
 * Rajshree Khare (@khareRajshree) <ansible.team@dell.com>
@@ -684,10 +691,10 @@ Manage device on Dell EMC PowerFlex
 --------------------------------
 # Info Module
 
-Gathering information about Dell EMC PowerFlex
+Gathering information about Dell PowerFlex
 
 ### Synopsis
- Gathering information about Dell EMC PowerFlex storage system includes getting the api details, list of volumes, SDSs, SDCs, storage pools, protection domains, snapshot policies, and devices.
+ Gathering information about Dell PowerFlex storage system includes getting the api details, list of volumes, SDSs, SDCs, storage pools, protection domains, snapshot policies, and devices.
 
 ### Parameters
                                                                                                                                                                                                                                                         
@@ -700,38 +707,6 @@ Gathering information about Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > gather_subset</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>vol</li>  <li>storage_pool</li>  <li>protection_domain</li>  <li>sdc</li>  <li>sds</li>  <li>snapshot_policy</li>  <li>device</li> </ul></td>
-            <td> <br> List of string variables to specify the Powerflex storage system entities for which information is required.  <br> Volumes - vol.  <br> Storage pools - storage_pool.  <br> Protection domains - protection_domain.  <br> SDCs - sdc.  <br> SDSs - sds.  <br> Snapshot policies - snapshot_policy.  <br> Devices - device. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > gateway_host</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
                     <tr>
             <td colspan=2 > filters</td>
             <td> list   <br> elements: dict </td>
@@ -741,6 +716,15 @@ Gathering information about Dell EMC PowerFlex
             <td> <br> List of filters to support filtered output for storage entities.  <br> Each filter is a list of filter_key, filter_operator, filter_value.  <br> Supports passing of multiple filters. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > filter_key </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name identifier of the filter.  </td>
+            </tr>
+                    <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > filter_value </td>
                 <td> str  </td>
@@ -758,22 +742,29 @@ Gathering information about Dell EMC PowerFlex
                 <td> <ul> <li>equal</li> </ul></td>
                 <td>  <br> Operation to be performed on filter key.  </td>
             </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > filter_key </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Name identifier of the filter.  </td>
-            </tr>
                             <tr>
-            <td colspan=2 > username</td>
-            <td> str  </td>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td></td>
             <td> True </td>
             <td></td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
             <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
         </tr>
                     <tr>
             <td colspan=2 > password</td>
@@ -784,18 +775,34 @@ Gathering information about Dell EMC PowerFlex
             <td> <br> The password of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
+            <td colspan=2 > gather_subset</td>
+            <td> list   <br> elements: str </td>
             <td></td>
+            <td></td>
+            <td> <ul> <li>vol</li>  <li>storage_pool</li>  <li>protection_domain</li>  <li>sdc</li>  <li>sds</li>  <li>snapshot_policy</li>  <li>device</li> </ul></td>
+            <td> <br> List of string variables to specify the Powerflex storage system entities for which information is required.  <br> Volumes - vol.  <br> Storage pools - storage_pool.  <br> Protection domains - protection_domain.  <br> SDCs - sdc.  <br> SDSs - sds.  <br> Snapshot policies - snapshot_policy.  <br> Devices - device. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > username</td>
+            <td> str  </td>
             <td> True </td>
             <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
         </tr>
-                                                                    </table>
+                    <tr>
+            <td colspan=2 > gateway_host</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                                                                                            </table>
 
 ### Notes
-* The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The check_mode is supported.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -837,7 +844,67 @@ Gathering information about Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
+                                            <tr>
+            <td colspan=2 > Snapshot_Policies </td>
+            <td>  list </td>
+            <td> always </td>
+            <td> Details of snapshot policies. </td>
+        </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> snapshot policy id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> snapshot policy name. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Devices </td>
+            <td>  list </td>
+            <td> always </td>
+            <td> Details of devices. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> device id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> device name. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > SDSs </td>
+            <td>  list </td>
+            <td> always </td>
+            <td> Details of storage data servers. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> storage data server id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> storage data server name. </td>
+            </tr>
+                                        <tr>
             <td colspan=2 > Storage_Pools </td>
             <td>  list </td>
             <td> always </td>
@@ -845,17 +912,69 @@ Gathering information about Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> storage pool id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
                 <td> storage pool name. </td>
             </tr>
-                                <tr>
+                                        <tr>
+            <td colspan=2 > API_Version </td>
+            <td>  str </td>
+            <td> always </td>
+            <td> API version of PowerFlex API Gateway. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > Volumes </td>
+            <td>  list </td>
+            <td> always </td>
+            <td> Details of volumes. </td>
+        </tr>
+                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> storage pool id. </td>
+                <td> volume id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> volume name. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Protection_Domains </td>
+            <td>  list </td>
+            <td> always </td>
+            <td> Details of all protection domains. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> protection domain id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> protection domain name. </td>
             </tr>
                                         <tr>
             <td colspan=2 > SDCs </td>
@@ -865,17 +984,17 @@ Gathering information about Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> storage data client name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> storage data client id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> storage data client name. </td>
             </tr>
                                         <tr>
             <td colspan=2 > Array_Details </td>
@@ -885,31 +1004,10 @@ Gathering information about Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > capacityTimeLeftInDays </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Capacity time left in days. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > installId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> installation Id. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > enterpriseFeaturesEnabled </td>
+                <td colspan=1 > isInitialLicense </td>
                 <td> bool </td>
                 <td>success</td>
-                <td> Enterprise eatures enabled. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > upgradeState </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Upgrade state. </td>
+                <td> Initial license. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -920,45 +1018,17 @@ Gathering information about Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > lastUpgradeTime </td>
+                <td colspan=1 > mdmManagementPort </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Last upgrade time. </td>
+                <td> MDM management port. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > mdmSecurityPolicy </td>
+                <td colspan=1 > authenticationMethod </td>
                 <td> str </td>
                 <td>success</td>
-                <td> MDM security policy. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > showGuid </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Show guid. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > systemVersionName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> System version and name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > maxCapacityInGb </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> Maximum capacity in GB. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The ID of the system. </td>
+                <td> Authentication method. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -976,20 +1046,6 @@ Gathering information about Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > isInitialLicense </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Initial license. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > addressSpaceUsage </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Address space usage. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > managementClientSecureCommunicationEnabled </td>
                 <td> bool </td>
                 <td>success</td>
@@ -997,17 +1053,31 @@ Gathering information about Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > capacityAlertCriticalThresholdPercent </td>
-                <td> int </td>
+                <td colspan=1 > mdmSecurityPolicy </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Capacity alert critical threshold percentage. </td>
+                <td> MDM security policy. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > mdmManagementPort </td>
-                <td> int </td>
+                <td colspan=1 > systemVersionName </td>
+                <td> str </td>
                 <td>success</td>
-                <td> MDM management port. </td>
+                <td> System version and name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > showGuid </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Show guid. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > maxCapacityInGb </td>
+                <td> dict </td>
+                <td>success</td>
+                <td> Maximum capacity in GB. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1018,6 +1088,13 @@ Gathering information about Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > capacityAlertHighThresholdPercent </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Capacity alert high threshold percentage. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > swid </td>
                 <td> str </td>
                 <td>success</td>
@@ -1025,10 +1102,59 @@ Gathering information about Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > authenticationMethod </td>
+                <td colspan=1 > enterpriseFeaturesEnabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Enterprise eatures enabled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > installId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Authentication method. </td>
+                <td> installation Id. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > lastUpgradeTime </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Last upgrade time. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > upgradeState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Upgrade state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > capacityAlertCriticalThresholdPercent </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Capacity alert critical threshold percentage. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > addressSpaceUsage </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Address space usage. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > capacityTimeLeftInDays </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Capacity time left in days. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1044,134 +1170,811 @@ Gathering information about Dell EMC PowerFlex
                 <td>success</td>
                 <td> Defragmentation enabled. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > capacityAlertHighThresholdPercent </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Capacity alert high threshold percentage. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Devices </td>
-            <td>  list </td>
-            <td> always </td>
-            <td> Details of devices. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> device name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> device id. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Snapshot_Policies </td>
-            <td>  list </td>
-            <td> always </td>
-            <td> Details of snapshot policies. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> snapshot policy name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> snapshot policy id. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > SDSs </td>
-            <td>  list </td>
-            <td> always </td>
-            <td> Details of storage data servers. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> storage data server name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> storage data server id. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Volumes </td>
-            <td>  list </td>
-            <td> always </td>
-            <td> Details of volumes. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> volume name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> volume id. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Protection_Domains </td>
-            <td>  list </td>
-            <td> always </td>
-            <td> Details of all protection domains. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> protection domain name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> protection domain id. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > API_Version </td>
-            <td>  str </td>
-            <td> always </td>
-            <td> API version of PowerFlex API Gateway. </td>
-        </tr>
-                                                                                    </table>
+                                                                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
 
 --------------------------------
+# MDM Cluster Module
+
+Manage MDM cluster on Dell PowerFlex
+
+### Synopsis
+ Managing MDM cluster and MDMs on PowerFlex storage system includes adding/removing standby MDM, modify MDM name and virtual interface.
+ It also includes getting details of MDM cluster, modify MDM cluster ownership, cluster mode, and performance profile.
+
+### Parameters
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+<table>
+    <tr>
+        <th colspan=2>Parameter</th>
+        <th width="20%">Type</th>
+        <th>Required</th>
+        <th>Default</th>
+        <th>Choices</th>
+        <th width="80%">Description</th>
+    </tr>
+                    <tr>
+            <td colspan=2 > virtual_ip_interfaces</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> List of interfaces to be used for virtual IPs.  <br> The order of interfaces must be matched with virtual IPs assigned to the cluster.  <br> Interfaces of the primary and secondary type MDMs are allowed to modify.  <br> The virtual_ip_interfaces is mutually exclusive with clear_interfaces. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > standby_mdm</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies add standby MDM parameters. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > management_ips </td>
+                <td> list   <br> elements: str </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> List of management IPs to manage MDM. It can contain IPv4 addresses.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > allow_multiple_ips </td>
+                <td> bool  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Allow the added node to have different number of IPs from the primary node.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > port </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Specifies the port of new MDM.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > virtual_interfaces </td>
+                <td> list   <br> elements: str </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> List of NIC interfaces that will be used for virtual IP addresses.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > role </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>Manager</li>  <li>TieBreaker</li> </ul></td>
+                <td>  <br> Role of new MDM.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > mdm_ips </td>
+                <td> list   <br> elements: str </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> List of MDM IPs that will be assigned to new MDM. It can contain IPv4 addresses.  </td>
+            </tr>
+                            <tr>
+            <td colspan=2 > mdm</td>
+            <td> list   <br> elements: dict </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies parameters to add/remove MDMs to/from the MDM cluster. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > mdm_name </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of MDM that will be added/removed to/from the cluster.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > mdm_type </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>Secondary</li>  <li>TieBreaker</li> </ul></td>
+                <td>  <br> Type of the MDM.  <br> Either mdm_id or mdm_name must be passed with mdm_type.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > mdm_id </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> ID of MDM that will be added/removed to/from the cluster.  </td>
+            </tr>
+                            <tr>
+            <td colspan=2 > mdm_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the MDM.  <br> Mutually exclusive with mdm_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > performance_profile</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>Compact</li>  <li>HighPerformance</li> </ul></td>
+            <td> <br> Apply performance profile to cluster MDMs. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > cluster_mode</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>OneNode</li>  <li>ThreeNodes</li>  <li>FiveNodes</li> </ul></td>
+            <td> <br> Mode of the cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > gateway_host</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > clear_interfaces</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Clear all virtual IP interfaces.  <br> The clear_interfaces is mutually exclusive with virtual_ip_interfaces. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > is_primary</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Set is_primary as True to change MDM cluster ownership from the current master MDM to different MDM.  <br> Set is_primary as False, will return MDM cluster details.  <br> New owner MDM must be an MDM with a manager role. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > mdm_new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> To rename the MDM. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the MDM cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > mdm_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the MDM. It is unique across the PowerFlex array.  <br> Mutually exclusive with mdm_id.  <br> If mdm_name passed in add standby operation, then same name will be assigned to the new standby mdm. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > mdm_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-cluster</li>  <li>absent-in-cluster</li> </ul></td>
+            <td> <br> Mapping state of MDM. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > username</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td></td>
+            <td> True </td>
+            <td></td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                                                                                            </table>
+
+### Notes
+* Parameters mdm_name or mdm_id are mandatory for rename and modify virtual IP interfaces.
+* Parameters mdm_name or mdm_id are not required while modifying performance profile.
+* For change MDM cluster ownership operation, only changed as True will be returned and for idempotency case MDM cluster details will be returned.
+* Reinstall all SDC after changing ownership to some newly added MDM.
+* To add manager standby MDM, MDM package must be installed with manager role.
+* The check mode is supported.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
+
+### Examples
+```
+- name: Add a standby MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    standby_mdm:
+      mdm_ips:
+        - "10.x.x.x"
+      role: "TieBreaker"
+      management_ips:
+        - "10.x.y.z"
+    state: "present"
+
+- name: Remove a standby MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    state: "absent"
+
+- name: Switch cluster mode from 3 node to 5 node MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    cluster_mode: "FiveNodes"
+    mdm:
+      - mdm_id: "5f091a8a013f1100"
+        mdm_type: "Secondary"
+      - mdm_name: "mdm_1"
+        mdm_type: "TieBreaker"
+    sdc_state: "present-in-cluster"
+    state: "present"
+
+- name: Switch cluster mode from 5 node to 3 node MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    cluster_mode: "ThreeNodes"
+    mdm:
+      - mdm_id: "5f091a8a013f1100"
+        mdm_type: "Secondary"
+      - mdm_name: "mdm_1"
+        mdm_type: "TieBreaker"
+    sdc_state: "absent-in-cluster"
+    state: "present"
+
+- name: Get the details of the MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    state: "present"
+
+- name: Change ownership of MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_2"
+    is_primary: True
+    state: "present"
+
+- name: Modify performance profile
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    performance_profile: "HighPerformance"
+    state: "present"
+
+- name: Rename the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    mdm_new_name: "new_mdm_1"
+    state: "present"
+
+- name: Modify virtual IP interface of the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    virtual_ip_interface:
+        - "ens224"
+    state: "present"
+
+- name: Clear virtual IP interface of the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    clear_interfaces: True
+    state: "present"
+```
+
+### Return Values
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+<table>
+    <tr>
+        <th colspan=6>Key</th>
+        <th>Type</th>
+        <th>Returned</th>
+        <th width="100%">Description</th>
+    </tr>
+                                            <tr>
+            <td colspan=6 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
+            <td colspan=6 > mdm_cluster_details </td>
+            <td>  complex </td>
+            <td> When MDM cluster exists </td>
+            <td> Details of the MDM cluster. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the MDM cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > goodReplicasNum </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Number of nodes for Replication. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > clusterState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> State of the MDM cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > tieBreakers </td>
+                <td> list </td>
+                <td>success</td>
+                <td> The list of the TieBreaker MDMs. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > opensslVersion </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> OpenSSL version. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > versionInfo </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Version of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > ips </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of IPs for tie-breaker MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > port </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Port of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Status of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > managementIPs </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of management IPs for tie-breaker MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > role </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Role of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the MDM. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > clusterMode </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Mode of the MDM cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > virtualIps </td>
+                <td> list </td>
+                <td>success</td>
+                <td> List of virtual IPs. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > standbyMDMs </td>
+                <td> list </td>
+                <td>success</td>
+                <td> The list of the standby MDMs. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > opensslVersion </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> OpenSSL version. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > versionInfo </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Version of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > ips </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of IPs for MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > port </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Port of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Status of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > managementIPs </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of management IPs for MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > role </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Role of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > virtualInterfaces </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of virtual interfaces </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of MDM cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > goodNodesNum </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Number of Nodes in MDM cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > slaves </td>
+                <td> list </td>
+                <td>success</td>
+                <td> The list of the secondary MDMs. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > opensslVersion </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> OpenSSL version. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > versionInfo </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Version of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > ips </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of IPs for secondary MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > port </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Port of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Status of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > managementIPs </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of management IPs for secondary MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > role </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Role of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > virtualInterfaces </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of virtual interfaces </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > master </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The details of the master MDM. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > opensslVersion </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> OpenSSL version. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > versionInfo </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Version of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > ips </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of IPs for master MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > port </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Port of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Status of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > managementIPs </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of management IPs for master MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > role </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Role of MDM. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > virtualInterfaces </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of virtual interfaces </td>
+                </tr>
+                                                                                                                    </table>
+
+### Authors
+* Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
+
+--------------------------------
 # Protection Domain Module
 
-Manage Protection Domain on Dell EMC PowerFlex
+Manage Protection Domain on Dell PowerFlex
 
 ### Synopsis
  Managing Protection Domain on PowerFlex storage system includes creating, modifying attributes, deleting and getting details of Protection Domain.
@@ -1187,14 +1990,6 @@ Manage Protection Domain on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the protection domain. </td>
-        </tr>
                     <tr>
             <td colspan=2 > timeout</td>
             <td> int  </td>
@@ -1204,12 +1999,20 @@ Manage Protection Domain on Dell EMC PowerFlex
             <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=2 > protection_domain_new_name</td>
+            <td colspan=2 > protection_domain_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Used to rename the protection domain. </td>
+            <td> <br> The name of the protection domain.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with protection_domain_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
         </tr>
                     <tr>
             <td colspan=2 > password</td>
@@ -1220,75 +2023,6 @@ Manage Protection Domain on Dell EMC PowerFlex
             <td> <br> The password of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > network_limits</td>
-            <td> dict  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Network bandwidth limit used by all SDS in protection domain. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > bandwidth_unit </td>
-                <td> str  </td>
-                <td></td>
-                <td> KBps </td>
-                <td> <ul> <li>KBps</li>  <li>MBps</li>  <li>GBps</li> </ul></td>
-                <td>  <br> Unit for network bandwidth limits.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > rebalance_limit </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Limit the network bandwidth for rebalance.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > vtree_migration_limit </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Limit the network bandwidth for vtree migration.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > rebuild_limit </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Limit the network bandwidth for rebuild.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > overall_limit </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Limit the overall network bandwidth.  </td>
-            </tr>
-                            <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td></td>
-            <td> True </td>
-            <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
             <td colspan=2 > is_active</td>
             <td> bool  </td>
             <td></td>
@@ -1297,20 +2031,12 @@ Manage Protection Domain on Dell EMC PowerFlex
             <td> <br> Used to activate or deactivate the protection domain. </td>
         </tr>
                     <tr>
-            <td colspan=2 > protection_domain_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the protection domain.  <br> Except for create operation, all other operations can be performed using protection_domain_id.  <br> Mutually exclusive with protection_domain_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > username</td>
+            <td colspan=2 > gateway_host</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
             <td colspan=2 > rf_cache_limits</td>
@@ -1322,12 +2048,12 @@ Manage Protection Domain on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > page_size </td>
-                <td> int  </td>
+                <td colspan=1 > is_enabled </td>
+                <td> bool  </td>
                 <td></td>
                 <td></td>
                 <td></td>
-                <td>  <br> Used to set the cache page size in KB.  </td>
+                <td>  <br> Used to enable or disable RFcache in the protection domain.  </td>
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1340,6 +2066,15 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > page_size </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Used to set the cache page size in KB.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > max_io_limit </td>
                 <td> int  </td>
                 <td></td>
@@ -1347,38 +2082,106 @@ Manage Protection Domain on Dell EMC PowerFlex
                 <td></td>
                 <td>  <br> Used to set cache maximum I/O limit in KB.  </td>
             </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_enabled </td>
-                <td> bool  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Used to enable or disable RFcache in the protection domain.  </td>
-            </tr>
                             <tr>
-            <td colspan=2 > protection_domain_name</td>
+            <td colspan=2 > protection_domain_new_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The name of the protection domain.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with protection_domain_id. </td>
+            <td> <br> Used to rename the protection domain. </td>
         </tr>
                     <tr>
-            <td colspan=2 > gateway_host</td>
+            <td colspan=2 > protection_domain_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the protection domain.  <br> Except for create operation, all other operations can be performed using protection_domain_id.  <br> Mutually exclusive with protection_domain_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the protection domain. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > network_limits</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Network bandwidth limit used by all SDS in protection domain. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > rebalance_limit </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Limit the network bandwidth for rebalance.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > rebuild_limit </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Limit the network bandwidth for rebuild.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > bandwidth_unit </td>
+                <td> str  </td>
+                <td></td>
+                <td> KBps </td>
+                <td> <ul> <li>KBps</li>  <li>MBps</li>  <li>GBps</li> </ul></td>
+                <td>  <br> Unit for network bandwidth limits.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > overall_limit </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Limit the overall network bandwidth.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > vtree_migration_limit </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Limit the network bandwidth for vtree migration.  </td>
+            </tr>
+                            <tr>
+            <td colspan=2 > username</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
         </tr>
-                                                                    </table>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td></td>
+            <td> True </td>
+            <td></td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                                                                                            </table>
 
 ### Notes
 * The protection domain can only be deleted if all its related objects have been dissociated from the protection domain.
 * If the protection domain set to inactive, then no operation can be performed on protection domain.
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -1473,13 +2276,33 @@ Manage Protection Domain on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
+                                            <tr>
+            <td colspan=6 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=6 > protection_domain_details </td>
             <td>  complex </td>
             <td> When protection domain exists </td>
             <td> Details of the protection domain. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > protectedMaintenanceModeNetworkThrottlingInKbps </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Protected maintenance mode network throttling in KBps. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > fglDefaultNumConcurrentWrites </td>
+                <td> str </td>
+                <td>success</td>
+                <td> FGL concurrent writes. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=5 > rfcachePageSizeKb </td>
                 <td> bool </td>
@@ -1488,17 +2311,10 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rfcacheEnabled </td>
+                <td colspan=5 > fglMetadataCacheEnabled </td>
                 <td> bool </td>
                 <td>success</td>
-                <td> Whether RF cache is enabled or not. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > protectedMaintenanceModeNetworkThrottlingEnabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether protected maintenance mode network throttling enabled. </td>
+                <td> Whether FGL cache enabled. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1509,17 +2325,10 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > overallIoNetworkThrottlingInKbps </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Overall network throttling in KBps. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > vtreeMigrationNetworkThrottlingEnabled </td>
+                <td colspan=5 > rfcacheEnabled </td>
                 <td> bool </td>
                 <td>success</td>
-                <td> Whether V-Tree migration network throttling enabled. </td>
+                <td> Whether RF cache is enabled or not. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1531,18 +2340,10 @@ Manage Protection Domain on Dell EMC PowerFlex
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > disconnectedClientName </td>
+                    <td colspan=4 > clientServerConnStatus </td>
                     <td> str </td>
                     <td>success</td>
-                    <td> Disconnected client name. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > disconnectedServerIp </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Disconnected server IP. </td>
+                    <td> Connectivity status of client and server. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -1555,6 +2356,22 @@ Manage Protection Domain on Dell EMC PowerFlex
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > disconnectedClientId </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Disconnected client ID. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > disconnectedClientName </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Disconnected client name. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > disconnectedServerName </td>
                     <td> str </td>
                     <td>success</td>
@@ -1563,32 +2380,45 @@ Manage Protection Domain on Dell EMC PowerFlex
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > clientServerConnStatus </td>
+                    <td colspan=4 > disconnectedServerIp </td>
                     <td> str </td>
                     <td>success</td>
-                    <td> Connectivity status of client and server. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > disconnectedClientId </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Disconnected client ID. </td>
+                    <td> Disconnected server IP. </td>
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rfcacheAccpId </td>
-                <td> str </td>
+                <td colspan=5 > rebalanceNetworkThrottlingInKbps </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Id of RF cache acceleration pool. </td>
+                <td> Rebalance network throttling in KBps. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > vtreeMigrationNetworkThrottlingInKbps </td>
+                <td colspan=5 > rfcacheMaxIoSizeKb </td>
                 <td> int </td>
                 <td>success</td>
-                <td> V-Tree migration network throttling in KBps. </td>
+                <td> RF cache maximum I/O size in KB. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > systemId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > rebalanceNetworkThrottlingEnabled </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Whether rebalance network throttling enabled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > storagePool </td>
+                <td> list </td>
+                <td>success</td>
+                <td> List of storage pools. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1606,65 +2436,6 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Protection domain ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rebuildNetworkThrottlingEnabled </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Whether rebuild network throttling enabled. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > fglDefaultNumConcurrentWrites </td>
-                <td> str </td>
-                <td>success</td>
-                <td> FGL concurrent writes. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > systemId </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > mdmSdsNetworkDisconnectionsCounterParameters </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> MDM's SDS counter parameter. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > shortWindow </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Short window for Counter Parameters. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > mediumWindow </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Medium window for Counter Parameters. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > longWindow </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Long window for Counter Parameters. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=5 > rfcacheOpertionalMode </td>
                 <td> str </td>
                 <td>success</td>
@@ -1672,17 +2443,24 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > fglMetadataCacheEnabled </td>
-                <td> bool </td>
+                <td colspan=5 > id </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Whether FGL cache enabled. </td>
+                <td> Protection domain ID. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rebalanceNetworkThrottlingInKbps </td>
-                <td> int </td>
+                <td colspan=5 > vtreeMigrationNetworkThrottlingEnabled </td>
+                <td> bool </td>
                 <td>success</td>
-                <td> Rebalance network throttling in KBps. </td>
+                <td> Whether V-Tree migration network throttling enabled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > rfcacheAccpId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Id of RF cache acceleration pool. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1709,17 +2487,31 @@ Manage Protection Domain on Dell EMC PowerFlex
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > protectedMaintenanceModeNetworkThrottlingInKbps </td>
+                <td colspan=5 > vtreeMigrationNetworkThrottlingInKbps </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Protected maintenance mode network throttling in KBps. </td>
+                <td> V-Tree migration network throttling in KBps. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rfcacheMaxIoSizeKb </td>
+                <td colspan=5 > protectedMaintenanceModeNetworkThrottlingEnabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether protected maintenance mode network throttling enabled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > rebuildNetworkThrottlingEnabled </td>
                 <td> int </td>
                 <td>success</td>
-                <td> RF cache maximum I/O size in KB. </td>
+                <td> Whether rebuild network throttling enabled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > protectionDomainState </td>
+                <td> int </td>
+                <td>success</td>
+                <td> State of protection domain. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1730,19 +2522,20 @@ Manage Protection Domain on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > storagePool </td>
-                <td> list </td>
-                <td>success</td>
-                <td> List of storage pools. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=5 > sdsSdsNetworkDisconnectionsCounterParameters </td>
                 <td> dict </td>
                 <td>success</td>
                 <td> Counter parameter for SDS-SDS network. </td>
             </tr>
                                          <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > longWindow </td>
+                    <td> int </td>
+                    <td>success</td>
+                    <td> Long window for Counter Parameters. </td>
+                </tr>
+                                             <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > shortWindow </td>
@@ -1758,7 +2551,21 @@ Manage Protection Domain on Dell EMC PowerFlex
                     <td>success</td>
                     <td> Medium window for Counter Parameters. </td>
                 </tr>
-                                             <tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > overallIoNetworkThrottlingInKbps </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Overall network throttling in KBps. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > mdmSdsNetworkDisconnectionsCounterParameters </td>
+                <td> dict </td>
+                <td>success</td>
+                <td> MDM's SDS counter parameter. </td>
+            </tr>
+                                         <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > longWindow </td>
@@ -1766,27 +2573,23 @@ Manage Protection Domain on Dell EMC PowerFlex
                     <td>success</td>
                     <td> Long window for Counter Parameters. </td>
                 </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > rebalanceNetworkThrottlingEnabled </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Whether rebalance network throttling enabled. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > protectionDomainState </td>
-                <td> int </td>
-                <td>success</td>
-                <td> State of protection domain. </td>
-            </tr>
-                                        <tr>
-            <td colspan=6 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                                    </table>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > shortWindow </td>
+                    <td> int </td>
+                    <td>success</td>
+                    <td> Short window for Counter Parameters. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > mediumWindow </td>
+                    <td> int </td>
+                    <td>success</td>
+                    <td> Medium window for Counter Parameters. </td>
+                </tr>
+                                                                                                                    </table>
 
 ### Authors
 * Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
@@ -1794,7 +2597,7 @@ Manage Protection Domain on Dell EMC PowerFlex
 --------------------------------
 # SDC Module
 
-Manage SDCs on Dell EMC PowerFlex
+Manage SDCs on Dell PowerFlex
 
 ### Synopsis
  Managing SDCs on PowerFlex storage system includes getting details of SDC and renaming SDC.
@@ -1810,45 +2613,13 @@ Manage SDCs on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
+                    <tr>
             <td colspan=1 > sdc_ip</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> IP of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip for get/rename operation.  <br> Mutually exclusive with sdc_id and sdc_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > sdc_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip for get/rename operation.  <br> Mutually exclusive with sdc_id and sdc_ip. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td></td>
-            <td> True </td>
-            <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the SDC. </td>
         </tr>
                     <tr>
             <td colspan=1 > timeout</td>
@@ -1859,20 +2630,12 @@ Manage SDCs on Dell EMC PowerFlex
             <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=1 > sdc_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip for get/rename operation.  <br> Mutually exclusive with sdc_name and sdc_ip. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > username</td>
+            <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the SDC. </td>
         </tr>
                     <tr>
             <td colspan=1 > sdc_new_name</td>
@@ -1883,12 +2646,52 @@ Manage SDCs on Dell EMC PowerFlex
             <td> <br> New name of the SDC. Used to rename the SDC. </td>
         </tr>
                     <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
             <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td></td>
+            <td> True </td>
+            <td></td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > username</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > sdc_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip for get/rename operation.  <br> Mutually exclusive with sdc_name and sdc_ip. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > sdc_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip for get/rename operation.  <br> Mutually exclusive with sdc_id and sdc_ip. </td>
         </tr>
                     <tr>
             <td colspan=1 > gateway_host</td>
@@ -1898,11 +2701,11 @@ Manage SDCs on Dell EMC PowerFlex
             <td></td>
             <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
         </tr>
-                                                                    </table>
+                                                                                            </table>
 
 ### Notes
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -1935,13 +2738,7 @@ Manage SDCs on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
-            <td colspan=3 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
+                                            <tr>
             <td colspan=3 > sdc_details </td>
             <td>  complex </td>
             <td> When SDC exists </td>
@@ -1949,10 +2746,31 @@ Manage SDCs on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the SDC. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sdcApproved </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates whether an SDC has approved access to the system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > name </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Name of the SDC. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sdcIp </td>
+                <td> str </td>
+                <td>success</td>
+                <td> IP of the SDC. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1962,14 +2780,6 @@ Manage SDCs on Dell EMC PowerFlex
                 <td> The details of the mapped volumes. </td>
             </tr>
                                          <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The name of the volume. </td>
-                </tr>
-                                             <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > id </td>
@@ -1985,6 +2795,14 @@ Manage SDCs on Dell EMC PowerFlex
                     <td>success</td>
                     <td> Type of the volume. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The name of the volume. </td>
+                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > osType </td>
@@ -1992,28 +2810,13 @@ Manage SDCs on Dell EMC PowerFlex
                 <td>success</td>
                 <td> OS type of the SDC. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sdcApproved </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Indicates whether an SDC has approved access to the system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The ID of the SDC. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sdcIp </td>
-                <td> str </td>
-                <td>success</td>
-                <td> IP of the SDC. </td>
-            </tr>
-                                                                                                        </table>
+                                        <tr>
+            <td colspan=3 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                                                                    </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -2021,7 +2824,7 @@ Manage SDCs on Dell EMC PowerFlex
 --------------------------------
 # SDS Module
 
-Manage SDS on Dell EMC PowerFlex
+Manage SDS on Dell PowerFlex
 
 ### Synopsis
  Managing SDS on PowerFlex storage system includes creating new SDS, getting details of SDS, adding/removing IP to/from SDS, modifying attributes of SDS, and deleting SDS.
@@ -2037,13 +2840,69 @@ Manage SDS on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
+                    <tr>
+            <td colspan=2 > rmcache_size</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Read RAM cache size (in MB).  <br> Minimum size is 128 MB.  <br> Maximum size is 3911 MB. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > protection_domain_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the protection domain.  <br> Mutually exclusive with protection_domain_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > performance_profile</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td> <ul> <li>Compact</li>  <li>HighPerformance</li> </ul></td>
             <td> <br> Performance profile to apply to the SDS.  <br> The HighPerformance profile configures a predefined set of parameters for very high performance use cases.  <br> Default value by API is "HighPerformance". </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > sds_ip_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-sds</li>  <li>absent-in-sds</li> </ul></td>
+            <td> <br> State of IP with respect to the SDS. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > sds_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the SDS.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with sds_id. </td>
         </tr>
                     <tr>
             <td colspan=2 > sds_new_name</td>
@@ -2054,12 +2913,60 @@ Manage SDS on Dell EMC PowerFlex
             <td> <br> SDS new name. </td>
         </tr>
                     <tr>
-            <td colspan=2 > sds_name</td>
+            <td colspan=2 > protection_domain_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The name of the SDS.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with sds_id. </td>
+            <td> <br> The ID of the protection domain.  <br> Mutually exclusive with protection_domain_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the SDS. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > sds_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the SDS.  <br> Except create operation, all other operations can be performed using sds_id.  <br> Mutually exclusive with sds_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > rmcache_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether to enable the Read RAM cache. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > gateway_host</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > username</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > rfcache_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether to enable the Read Flash cache. </td>
         </tr>
                     <tr>
             <td colspan=2 > sds_ip_list</td>
@@ -2071,15 +2978,6 @@ Manage SDS on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > role </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td> <ul> <li>sdsOnly</li>  <li>sdcOnly</li>  <li>all</li> </ul></td>
-                <td>  <br> Role assigned to the SDS IP address.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > ip </td>
                 <td> str  </td>
                 <td> True </td>
@@ -2087,71 +2985,16 @@ Manage SDS on Dell EMC PowerFlex
                 <td></td>
                 <td>  <br> IP address of the SDS.  </td>
             </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > role </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>sdsOnly</li>  <li>sdcOnly</li>  <li>all</li> </ul></td>
+                <td>  <br> Role assigned to the SDS IP address.  </td>
+            </tr>
                             <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the SDS. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > sds_ip_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>present-in-sds</li>  <li>absent-in-sds</li> </ul></td>
-            <td> <br> State of IP with respect to the SDS. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > rfcache_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Whether to enable the Read Flash cache. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > rmcache_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Whether to enable the Read RAM cache. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > rmcache_size</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Read RAM cache size (in MB).  <br> Minimum size is 128 MB.  <br> Maximum size is 3911 MB. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
             <td colspan=2 > verifycert</td>
             <td> bool  </td>
             <td></td>
@@ -2159,47 +3002,7 @@ Manage SDS on Dell EMC PowerFlex
             <td></td>
             <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
         </tr>
-                    <tr>
-            <td colspan=2 > protection_domain_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the protection domain.  <br> Mutually exclusive with protection_domain_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > username</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > protection_domain_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the protection domain.  <br> Mutually exclusive with protection_domain_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > sds_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the SDS.  <br> Except create operation, all other operations can be performed using sds_id.  <br> Mutually exclusive with sds_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > gateway_host</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
-        </tr>
-                                                                    </table>
+                                                                                            </table>
 
 ### Notes
 * The maximum limit for the IPs that can be associated with an SDS is 8.
@@ -2209,7 +3012,7 @@ Manage SDS on Dell EMC PowerFlex
 * There must be only 1 IP with SDS role (either with role 'all' or 'sdsOnly').
 * SDS can be created with RF cache disabled, but, be aware that the RF cache is not always updated. In this case, the user should re-try the operation.
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -2354,7 +3157,13 @@ Manage SDS on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
+                                            <tr>
+            <td colspan=4 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=4 > sds_details </td>
             <td>  complex </td>
             <td> When SDS exists </td>
@@ -2362,80 +3171,17 @@ Manage SDS on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > sdsReceiveBufferAllocationFailures </td>
-                <td> str </td>
-                <td>success</td>
-                <td> SDS receive buffer allocation failures. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rfcacheEnabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether RF cache is enabled or not. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > lastUpgradeTime </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Last time SDS was upgraded. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > sdsDecoupled </td>
-                <td> str </td>
-                <td>success</td>
-                <td> SDS decoupled. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rfcacheErrorDeviceDoesNotExist </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> RF cache error for device does not exist. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > fglMetadataCacheState </td>
-                <td> str </td>
-                <td>success</td>
-                <td> FGL metadata cache state. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rmcacheEnabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether Read RAM cache is enabled or not. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > numOfIoBuffers </td>
+                <td colspan=3 > rmcacheSizeInKb </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Number of IO buffers. </td>
+                <td> RM cache size in KB. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > faultSetId </td>
+                <td colspan=3 > drlMode </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Fault set ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > onVmWare </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Presence on VMware. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rmcacheMemoryAllocationState </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> RM cache memory allocation state. </td>
+                <td> DRL mode. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2446,24 +3192,38 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rmcacheSizeInMb </td>
+                <td colspan=3 > numOfIoBuffers </td>
                 <td> int </td>
                 <td>success</td>
-                <td> RM cache size in MB. </td>
+                <td> Number of IO buffers. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > protectionDomainId </td>
-                <td> str </td>
+                <td colspan=3 > rfcacheErrorDeviceDoesNotExist </td>
+                <td> bool </td>
                 <td>success</td>
-                <td> Protection Domain ID. </td>
+                <td> RF cache error for device does not exist. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > certificateInfo </td>
+                <td colspan=3 > rmcacheEnabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether Read RAM cache is enabled or not. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > mdmConnectionState </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Information about certificate. </td>
+                <td> MDM connection state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > sdsState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> SDS state. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2474,10 +3234,17 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rmcacheSizeInKb </td>
-                <td> int </td>
+                <td colspan=3 > softwareVersionInfo </td>
+                <td> str </td>
                 <td>success</td>
-                <td> RM cache size in KB. </td>
+                <td> SDS software version information. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > rmcacheMemoryAllocationState </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> RM cache memory allocation state. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2488,31 +3255,45 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rfcacheErrorInconsistentCacheConfiguration </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> RF cache error for inconsistent cache configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > numRestarts </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Number of restarts. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> SDS ID. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > rfcacheErrorInconsistentSourceConfiguration </td>
                 <td> bool </td>
                 <td>success</td>
                 <td> RF cache error for inconsistent source configuration. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > rfcacheEnabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether RF cache is enabled or not. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > faultSetId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Fault set ID. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > sdsDecoupled </td>
+                <td> str </td>
+                <td>success</td>
+                <td> SDS decoupled. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > lastUpgradeTime </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Last time SDS was upgraded. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > onVmWare </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Presence on VMware. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2523,24 +3304,17 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > protectionDomainName </td>
+                <td colspan=3 > certificateInfo </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Protection Domain Name. </td>
+                <td> Information about certificate. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > rfcacheErrorApiVersionMismatch </td>
-                <td> bool </td>
+                <td colspan=3 > sdsReceiveBufferAllocationFailures </td>
+                <td> str </td>
                 <td>success</td>
-                <td> RF cache error for API version mismatch. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > fglNumConcurrentWrites </td>
-                <td> int </td>
-                <td>success</td>
-                <td> FGL concurrent writes. </td>
+                <td> SDS receive buffer allocation failures. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2552,32 +3326,39 @@ Manage SDS on Dell EMC PowerFlex
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > role </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Role of the SDS IP. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=2 > ip </td>
                     <td> str </td>
                     <td>success</td>
                     <td> IP present in the SDS. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > role </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Role of the SDS IP. </td>
+                </tr>
                                                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > authenticationError </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Indicates authentication error. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > membershipState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Membership state. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > configuredDrlMode </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Configured DRL mode. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > mdmConnectionState </td>
-                <td> str </td>
-                <td>success</td>
-                <td> MDM connection state. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2588,10 +3369,24 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > raidControllers </td>
-                <td> int </td>
+                <td colspan=3 > rfcacheErrorApiVersionMismatch </td>
+                <td> bool </td>
                 <td>success</td>
-                <td> Number of RAID controllers. </td>
+                <td> RF cache error for API version mismatch. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > protectionDomainName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Protection Domain Name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > maintenanceType </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Maintenance type. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2602,17 +3397,24 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > softwareVersionInfo </td>
+                <td colspan=3 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> SDS software version information. </td>
+                <td> SDS ID. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > sdsConfigurationFailure </td>
-                <td> str </td>
+                <td colspan=3 > port </td>
+                <td> int </td>
                 <td>success</td>
-                <td> SDS configuration failure. </td>
+                <td> SDS port. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > numRestarts </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Number of restarts. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2639,24 +3441,45 @@ Manage SDS on Dell EMC PowerFlex
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > maintenanceType </td>
-                <td> str </td>
+                <td colspan=3 > rfcacheErrorInconsistentCacheConfiguration </td>
+                <td> bool </td>
                 <td>success</td>
-                <td> Maintenance type. </td>
+                <td> RF cache error for inconsistent cache configuration. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > port </td>
+                <td colspan=3 > fglMetadataCacheState </td>
+                <td> str </td>
+                <td>success</td>
+                <td> FGL metadata cache state. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > fglNumConcurrentWrites </td>
                 <td> int </td>
                 <td>success</td>
-                <td> SDS port. </td>
+                <td> FGL concurrent writes. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > sdsState </td>
+                <td colspan=3 > raidControllers </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Number of RAID controllers. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > sdsConfigurationFailure </td>
                 <td> str </td>
                 <td>success</td>
-                <td> SDS state. </td>
+                <td> SDS configuration failure. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > protectionDomainId </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Protection Domain ID. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2667,32 +3490,12 @@ Manage SDS on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > authenticationError </td>
-                <td> str </td>
+                <td colspan=3 > rmcacheSizeInMb </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Indicates authentication error. </td>
+                <td> RM cache size in MB. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > drlMode </td>
-                <td> str </td>
-                <td>success</td>
-                <td> DRL mode. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > membershipState </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Membership state. </td>
-            </tr>
-                                        <tr>
-            <td colspan=4 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                                    </table>
+                                                                                        </table>
 
 ### Authors
 * Rajshree Khare (@khareRajshree) <ansible.team@dell.com>
@@ -2700,7 +3503,7 @@ Manage SDS on Dell EMC PowerFlex
 --------------------------------
 # Snapshot Module
 
-Manage Snapshots on Dell EMC PowerFlex
+Manage Snapshots on Dell PowerFlex
 
 ### Synopsis
  Managing snapshots on PowerFlex Storage System includes creating, getting details, mapping/unmapping to/from SDC, modifying the attributes and deleting snapshot.
@@ -2716,30 +3519,6 @@ Manage Snapshots on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=2 > retention_unit</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>hours</li>  <li>days</li> </ul></td>
-            <td> <br> The unit for retention. It defaults to 'hours', if not specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vol_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the volume for which snapshot will be taken.  <br> Specify either vol_name or vol_id while creating snapshot. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the snapshot. </td>
-        </tr>
                     <tr>
             <td colspan=2 > size</td>
             <td> int  </td>
@@ -2747,6 +3526,14 @@ Manage Snapshots on Dell EMC PowerFlex
             <td></td>
             <td></td>
             <td> <br> The size of the snapshot. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
             <td colspan=2 > sdc_state</td>
@@ -2757,12 +3544,28 @@ Manage Snapshots on Dell EMC PowerFlex
             <td> <br> Mapping state of the SDC. </td>
         </tr>
                     <tr>
-            <td colspan=2 > snapshot_id</td>
+            <td colspan=2 > vol_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The ID of the Snapshot. </td>
+            <td> <br> The name of the volume for which snapshot will be taken.  <br> Specify either vol_name or vol_id while creating snapshot. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > vol_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the volume. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
         </tr>
                     <tr>
             <td colspan=2 > password</td>
@@ -2771,6 +3574,62 @@ Manage Snapshots on Dell EMC PowerFlex
             <td></td>
             <td></td>
             <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > snapshot_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the Snapshot. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > remove_mode</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>ONLY_ME</li>  <li>INCLUDING_DESCENDANTS</li> </ul></td>
+            <td> <br> Removal mode for the snapshot.  <br> It defaults to 'ONLY_ME', if not specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > allow_multiple_mappings</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies whether to allow multiple mappings or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > read_only</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies whether mapping of the created snapshot volume will have read-write access or limited to read-only access.  <br> If true, snapshot is created with read-only access.  <br> If false, snapshot is created with read-write access. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > snapshot_new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New name of the snapshot. Used to rename the snapshot. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > desired_retention</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The retention value for the Snapshot.  <br> If the desired_retention is not mentioned during creation, snapshot will be created with unlimited retention.  <br> Maximum supported desired retention is 31 days. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > snapshot_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the snapshot.  <br> Mandatory for create operation.  <br> Specify either snapshot name or ID (but not both) for any operation. </td>
         </tr>
                     <tr>
             <td colspan=2 > sdc</td>
@@ -2788,6 +3647,15 @@ Manage Snapshots on Dell EMC PowerFlex
                 <td></td>
                 <td></td>
                 <td>  <br> IP of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_id and sdc_ip.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > sdc_id </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_name and sdc_ip.  </td>
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2818,15 +3686,6 @@ Manage Snapshots on Dell EMC PowerFlex
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > sdc_id </td>
-                <td> str  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_name and sdc_ip.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > bandwidth_limit </td>
                 <td> int  </td>
                 <td></td>
@@ -2835,60 +3694,20 @@ Manage Snapshots on Dell EMC PowerFlex
                 <td>  <br> Limit of snapshot network bandwidth.  <br> Need to mention in multiple of 1024 Kbps.  <br> To set no limit, 0 is to be passed.  </td>
             </tr>
                             <tr>
-            <td colspan=2 > remove_mode</td>
+            <td colspan=2 > state</td>
             <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>ONLY_ME</li>  <li>INCLUDING_DESCENDANTS</li> </ul></td>
-            <td> <br> Removal mode for the snapshot.  <br> It defaults to 'ONLY_ME', if not specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > allow_multiple_mappings</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Specifies whether to allow multiple mappings or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td></td>
             <td> True </td>
             <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the snapshot. </td>
         </tr>
                     <tr>
-            <td colspan=2 > snapshot_new_name</td>
+            <td colspan=2 > retention_unit</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> New name of the snapshot. Used to rename the snapshot. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > snapshot_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the snapshot.  <br> Mandatory for create operation.  <br> Specify either snapshot name or ID (but not both) for any operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > desired_retention</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The retention value for the Snapshot.  <br> If the desired_retention is not mentioned during creation, snapshot will be created with unlimited retention.  <br> Maximum supported desired retention is 31 days. </td>
+            <td> <ul> <li>hours</li>  <li>days</li> </ul></td>
+            <td> <br> The unit for retention. It defaults to 'hours', if not specified. </td>
         </tr>
                     <tr>
             <td colspan=2 > cap_unit</td>
@@ -2907,14 +3726,6 @@ Manage Snapshots on Dell EMC PowerFlex
             <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > read_only</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Specifies whether mapping of the created snapshot volume will have read-write access or limited to read-only access.  <br> If true, snapshot is created with read-only access.  <br> If false, snapshot is created with read-write access. </td>
-        </tr>
-                    <tr>
             <td colspan=2 > username</td>
             <td> str  </td>
             <td> True </td>
@@ -2923,26 +3734,18 @@ Manage Snapshots on Dell EMC PowerFlex
             <td> <br> The username of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > vol_id</td>
-            <td> str  </td>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
             <td></td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> The ID of the volume. </td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
         </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                                                                    </table>
+                                                                                            </table>
 
 ### Notes
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -3052,7 +3855,7 @@ Manage Snapshots on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
+                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -3066,24 +3869,31 @@ Manage Snapshots on Dell EMC PowerFlex
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > retentionInHours </td>
+                <td colspan=2 > secureSnapshotExpTime </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Retention of the snapshot in hours. </td>
+                <td> Expiry time of the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > creationTime </td>
-                <td> int </td>
-                <td>success</td>
-                <td> The creation time of the snapshot. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > storagePoolId </td>
+                <td colspan=2 > ancestorVolumeName </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The ID of the Storage pool in which snapshot resides. </td>
+                <td> The name of the root of the specified volume's V-Tree. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sizeInKb </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sizeInGb </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3095,10 +3905,10 @@ Manage Snapshots on Dell EMC PowerFlex
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > sdcName </td>
-                    <td> str </td>
+                    <td colspan=1 > limitBwInMbps </td>
+                    <td> int </td>
                     <td>success</td>
-                    <td> Name of the SDC. </td>
+                    <td> Bandwidth limit for the SDC. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -3107,6 +3917,22 @@ Manage Snapshots on Dell EMC PowerFlex
                     <td> str </td>
                     <td>success</td>
                     <td> mapping access mode for the specified snapshot. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > sdcName </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the SDC. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > sdcIp </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> IP of the SDC. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -3124,49 +3950,19 @@ Manage Snapshots on Dell EMC PowerFlex
                     <td>success</td>
                     <td> ID of the SDC. </td>
                 </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > limitBwInMbps </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Bandwidth limit for the SDC. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > sdcIp </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> IP of the SDC. </td>
-                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > ancestorVolumeId </td>
+                <td colspan=2 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The ID of the root of the specified volume's V-Tree. </td>
+                <td> The ID of the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sizeInGb </td>
+                <td colspan=2 > retentionInHours </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Size of the snapshot. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the snapshot. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sizeInKb </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Size of the snapshot. </td>
+                <td> Retention of the snapshot in hours. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3177,26 +3973,33 @@ Manage Snapshots on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
+                <td colspan=2 > storagePoolId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The ID of the snapshot. </td>
+                <td> The ID of the Storage pool in which snapshot resides. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > secureSnapshotExpTime </td>
+                <td colspan=2 > creationTime </td>
                 <td> int </td>
                 <td>success</td>
-                <td> Expiry time of the snapshot. </td>
+                <td> The creation time of the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > ancestorVolumeName </td>
+                <td colspan=2 > ancestorVolumeId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The name of the root of the specified volume's V-Tree. </td>
+                <td> The ID of the root of the specified volume's V-Tree. </td>
             </tr>
-                                                                                                        </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the snapshot. </td>
+            </tr>
+                                                                                        </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -3204,10 +4007,10 @@ Manage Snapshots on Dell EMC PowerFlex
 --------------------------------
 # Storage Pool Module
 
-Managing Dell EMC PowerFlex storage pool
+Managing Dell PowerFlex storage pool
 
 ### Synopsis
- Dell EMC PowerFlex storage pool module includes getting the details of storage pool, creating a new storage pool, and modifying the attribute of a storage pool.
+ Dell PowerFlex storage pool module includes getting the details of storage pool, creating a new storage pool, and modifying the attribute of a storage pool.
 
 ### Parameters
                                                                                                                                                                                                                                                                                                                                                             
@@ -3220,30 +4023,6 @@ Managing Dell EMC PowerFlex storage pool
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=1 > storage_pool_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the storage pool.  <br> If more than one storage pool is found with the same name then protection domain id/name is required to perform the task.  <br> Mutually exclusive with storage_pool_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the storage pool. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > use_rmcache</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Enable/Disable RMcache on a specific storage pool. </td>
-        </tr>
                     <tr>
             <td colspan=1 > timeout</td>
             <td> int  </td>
@@ -3251,30 +4030,6 @@ Managing Dell EMC PowerFlex storage pool
             <td> 120 </td>
             <td></td>
             <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > media_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>HDD</li>  <li>SSD</li>  <li>TRANSITIONAL</li> </ul></td>
-            <td> <br> Type of devices in the storage pool. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > storage_pool_new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> New name for the storage pool can be provided.  <br> This parameter is used for renaming the storage pool. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerFlex gateway host. </td>
         </tr>
                     <tr>
             <td colspan=1 > protection_domain_name</td>
@@ -3293,12 +4048,44 @@ Managing Dell EMC PowerFlex storage pool
             <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
         </tr>
                     <tr>
+            <td colspan=1 > media_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>HDD</li>  <li>SSD</li>  <li>TRANSITIONAL</li> </ul></td>
+            <td> <br> Type of devices in the storage pool. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > use_rmcache</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Enable/Disable RMcache on a specific storage pool. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > storage_pool_new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New name for the storage pool can be provided.  <br> This parameter is used for renaming the storage pool. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > gateway_host</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
             <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > use_rfcache</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Enable/Disable RFcache on a specific storage pool. </td>
         </tr>
                     <tr>
             <td colspan=1 > protection_domain_id</td>
@@ -3309,20 +4096,36 @@ Managing Dell EMC PowerFlex storage pool
             <td> <br> The id of the protection domain.  <br> During creation of a pool, either protection domain name or id must be mentioned.  <br> Mutually exclusive with protection_domain_name. </td>
         </tr>
                     <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the storage pool. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > storage_pool_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the storage pool.  <br> If more than one storage pool is found with the same name then protection domain id/name is required to perform the task.  <br> Mutually exclusive with storage_pool_id. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > username</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
             <td> <br> The username of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > use_rfcache</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Enable/Disable RFcache on a specific storage pool. </td>
         </tr>
                     <tr>
             <td colspan=1 > storage_pool_id</td>
@@ -3340,12 +4143,12 @@ Managing Dell EMC PowerFlex storage pool
             <td></td>
             <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
         </tr>
-                                                                    </table>
+                                                                                            </table>
 
 ### Notes
 * TRANSITIONAL media type is supported only during modification.
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -3411,7 +4214,13 @@ Managing Dell EMC PowerFlex storage pool
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
+                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > storage_pool_details </td>
             <td>  complex </td>
             <td> When storage pool exists </td>
@@ -3419,17 +4228,17 @@ Managing Dell EMC PowerFlex storage pool
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
+                <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the storage pool under protection domain. </td>
+                <td> ID of the storage pool under protection domain. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protectionDomainId </td>
-                <td> str </td>
+                <td colspan=1 > useRfcache </td>
+                <td> bool </td>
                 <td>success</td>
-                <td> ID of the protection domain in which pool resides. </td>
+                <td> Enable/Disable RFcache on a specific storage pool. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3447,17 +4256,17 @@ Managing Dell EMC PowerFlex storage pool
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > useRfcache </td>
-                <td> bool </td>
+                <td colspan=1 > name </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Enable/Disable RFcache on a specific storage pool. </td>
+                <td> Name of the storage pool under protection domain. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
+                <td colspan=1 > protectionDomainId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the storage pool under protection domain. </td>
+                <td> ID of the protection domain in which pool resides. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3466,13 +4275,7 @@ Managing Dell EMC PowerFlex storage pool
                 <td>success</td>
                 <td> Type of devices in the storage pool. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                                    </table>
+                                                                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -3481,7 +4284,7 @@ Managing Dell EMC PowerFlex storage pool
 --------------------------------
 # Volume Module
 
-Manage volumes on Dell EMC PowerFlex
+Manage volumes on Dell PowerFlex
 
 ### Synopsis
  Managing volumes on PowerFlex storage system includes creating, getting details, modifying attributes and deleting volume.
@@ -3498,101 +4301,13 @@ Manage volumes on Dell EMC PowerFlex
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                                            <tr>
-            <td colspan=2 > storage_pool_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the storage pool.  <br> Either name or the id of the storage pool is required for creating a volume.  <br> During creation, if storage pool name is provided then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with storage_pool_id. </td>
-        </tr>
                     <tr>
-            <td colspan=2 > use_rmcache</td>
-            <td> bool  </td>
+            <td colspan=2 > size</td>
+            <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Whether to use RM Cache or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > sdc_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>mapped</li>  <li>unmapped</li> </ul></td>
-            <td> <br> Mapping state of the SDC. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > snapshot_policy_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > protection_domain_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the protection domain.  <br> During creation of a volume, if more than one storage pool exists with the same name then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with protection_domain_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > gateway_host</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vol_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>THICK_PROVISIONED</li>  <li>THIN_PROVISIONED</li> </ul></td>
-            <td> <br> Type of volume provisioning. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > compression_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>NORMAL</li>  <li>NONE</li> </ul></td>
-            <td> <br> Type of the compression method. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vol_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the volume.  <br> Except create operation, all other operations can be performed using vol_id.  <br> Mutually exclusive with vol_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > cap_unit</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
-            <td> <br> The unit of the volume size. It defaults to 'GB'. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vol_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the volume.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with vol_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> State of the volume. </td>
+            <td> <br> The size of the volume.  <br> Size of the volume will be assigned as higher multiple of 8 GB. </td>
         </tr>
                     <tr>
             <td colspan=2 > timeout</td>
@@ -3603,28 +4318,52 @@ Manage volumes on Dell EMC PowerFlex
             <td> <br> Time after which connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=2 > size</td>
+            <td colspan=2 > auto_snap_remove_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>remove</li>  <li>detach</li> </ul></td>
+            <td> <br> Whether to remove or detach the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type.  <br> If the snapshot policy name/id is passed empty then auto_snap_remove_type is defaulted to 'detach'. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > vol_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the volume.  <br> Mandatory for create operation.  <br> It is unique across the PowerFlex array.  <br> Mutually exclusive with vol_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > protection_domain_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the protection domain.  <br> During creation of a volume, if more than one storage pool exists with the same name then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with protection_domain_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > vol_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the volume.  <br> Except create operation, all other operations can be performed using vol_id.  <br> Mutually exclusive with vol_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
             <td> int  </td>
             <td></td>
+            <td> 443 </td>
             <td></td>
-            <td></td>
-            <td> <br> The size of the volume.  <br> Size of the volume will be assigned as higher multiple of 8 GB. </td>
+            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > snapshot_policy_id</td>
+            <td colspan=2 > vol_type</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> ID of the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerFlex gateway host. </td>
+            <td> <ul> <li>THICK_PROVISIONED</li>  <li>THIN_PROVISIONED</li> </ul></td>
+            <td> <br> Type of volume provisioning. </td>
         </tr>
                     <tr>
             <td colspan=2 > sdc</td>
@@ -3642,6 +4381,15 @@ Manage volumes on Dell EMC PowerFlex
                 <td></td>
                 <td></td>
                 <td>  <br> IP of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_id and sdc_ip.  </td>
+            </tr>
+                    <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > sdc_id </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_name and sdc_ip.  </td>
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3672,15 +4420,6 @@ Manage volumes on Dell EMC PowerFlex
             </tr>
                     <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > sdc_id </td>
-                <td> str  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> ID of the SDC.  <br> Specify either sdc_name, sdc_id or sdc_ip.  <br> Mutually exclusive with sdc_name and sdc_ip.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > bandwidth_limit </td>
                 <td> int  </td>
                 <td></td>
@@ -3689,12 +4428,20 @@ Manage volumes on Dell EMC PowerFlex
                 <td>  <br> Limit of volume network bandwidth.  <br> Need to mention in multiple of 1024 Kbps.  <br> To set no limit, 0 is to be passed.  </td>
             </tr>
                             <tr>
-            <td colspan=2 > delete_snapshots</td>
+            <td colspan=2 > protection_domain_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the protection domain.  <br> During creation of a volume, if more than one storage pool exists with the same name then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with protection_domain_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
             <td> bool  </td>
             <td></td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> If True, the volume and all its dependent snapshots will be deleted.  <br> If False, only the volume will be deleted.  <br> It can be specified only when the state is absent.  <br> It defaults to False, if not specified. </td>
+            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
             <td colspan=2 > allow_multiple_mappings</td>
@@ -3705,20 +4452,92 @@ Manage volumes on Dell EMC PowerFlex
             <td> <br> Specifies whether to allow multiple mappings or not.  <br> If the volume is mapped to one SDC then for every new mapping allow_multiple_mappings has to be passed as True. </td>
         </tr>
                     <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Port number through which communication happens with PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > auto_snap_remove_type</td>
+            <td colspan=2 > sdc_state</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td> <ul> <li>remove</li>  <li>detach</li> </ul></td>
-            <td> <br> Whether to remove or detach the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type.  <br> If the snapshot policy name/id is passed empty then auto_snap_remove_type is defaulted to 'detach'. </td>
+            <td> <ul> <li>mapped</li>  <li>unmapped</li> </ul></td>
+            <td> <br> Mapping state of the SDC. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > snapshot_policy_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > compression_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>NORMAL</li>  <li>NONE</li> </ul></td>
+            <td> <br> Type of the compression method. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > snapshot_policy_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID of the snapshot policy.  <br> To remove/detach snapshot policy, empty snapshot_policy_id/snapshot_policy_name is to be passed along with auto_snap_remove_type. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > gateway_host</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerFlex gateway host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > use_rmcache</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether to use RM Cache or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > cap_unit</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
+            <td> <br> The unit of the volume size. It defaults to 'GB'. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > delete_snapshots</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> If True, the volume and all its dependent snapshots will be deleted.  <br> If False, only the volume will be deleted.  <br> It can be specified only when the state is absent.  <br> It defaults to False, if not specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> State of the volume. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > storage_pool_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the storage pool.  <br> Either name or the id of the storage pool is required for creating a volume.  <br> During creation, if storage pool name is provided then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with storage_pool_id. </td>
         </tr>
                     <tr>
             <td colspan=2 > vol_new_name</td>
@@ -3729,22 +4548,6 @@ Manage volumes on Dell EMC PowerFlex
             <td> <br> New name of the volume. Used to rename the volume. </td>
         </tr>
                     <tr>
-            <td colspan=2 > username</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerFlex gateway host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > protection_domain_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the protection domain.  <br> During creation of a volume, if more than one storage pool exists with the same name then either protection domain name or id must be mentioned along with it.  <br> Mutually exclusive with protection_domain_id. </td>
-        </tr>
-                    <tr>
             <td colspan=2 > storage_pool_id</td>
             <td> str  </td>
             <td></td>
@@ -3753,18 +4556,18 @@ Manage volumes on Dell EMC PowerFlex
             <td> <br> The ID of the storage pool.  <br> Either name or the id of the storage pool is required for creating a volume.  <br> Mutually exclusive with storage_pool_name. </td>
         </tr>
                     <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td></td>
+            <td colspan=2 > username</td>
+            <td> str  </td>
             <td> True </td>
             <td></td>
-            <td> <br> Boolean variable to specify whether or not to validate SSL certificate.  <br> True - Indicates that the SSL certificate should be verified.  <br> False - Indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td> <br> The username of the PowerFlex gateway host. </td>
         </tr>
-                                                                    </table>
+                                                                                            </table>
 
 ### Notes
 * The check_mode is not supported.
-* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell EMC PowerFlex storage platform.
+* The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 ### Examples
 ```
@@ -3887,33 +4690,13 @@ Manage volumes on Dell EMC PowerFlex
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                            <tr>
-            <td colspan=3 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
+                                            <tr>
             <td colspan=3 > volume_details </td>
             <td>  complex </td>
             <td> When volume exists </td>
             <td> Details of the volume. </td>
         </tr>
                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > snapshotPolicyName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the snapshot policy associated with volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > protectionDomainName </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the protection domain in which volume resides. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > snapshotPolicyId </td>
                 <td> str </td>
@@ -3922,10 +4705,24 @@ Manage volumes on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > storagePoolId </td>
+                <td colspan=2 > snapshotsList </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the storage pool in which volume resides. </td>
+                <td> List of snapshots associated with the volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > snapshotPolicyName </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the snapshot policy associated with volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sizeInGb </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the volume in Gb. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3937,10 +4734,10 @@ Manage volumes on Dell EMC PowerFlex
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > sdcName </td>
-                    <td> str </td>
+                    <td colspan=1 > limitBwInMbps </td>
+                    <td> int </td>
                     <td>success</td>
-                    <td> Name of the SDC. </td>
+                    <td> Bandwidth limit for the SDC. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -3949,6 +4746,22 @@ Manage volumes on Dell EMC PowerFlex
                     <td> str </td>
                     <td>success</td>
                     <td> mapping access mode for the specified volume. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > sdcName </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the SDC. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > sdcIp </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> IP of the SDC. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -3966,49 +4779,19 @@ Manage volumes on Dell EMC PowerFlex
                     <td>success</td>
                     <td> ID of the SDC. </td>
                 </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > limitBwInMbps </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Bandwidth limit for the SDC. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > sdcIp </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> IP of the SDC. </td>
-                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sizeInKb </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Size of the volume in Kb. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > sizeInGb </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Size of the volume in Gb. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
+                <td colspan=2 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the volume. </td>
+                <td> The ID of the volume. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > protectionDomainId </td>
+                <td colspan=2 > protectionDomainName </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the protection domain in which volume resides. </td>
+                <td> Name of the protection domain in which volume resides. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4019,19 +4802,39 @@ Manage volumes on Dell EMC PowerFlex
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > snapshotsList </td>
+                <td colspan=2 > storagePoolId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> List of snapshots associated with the volume. </td>
+                <td> ID of the storage pool in which volume resides. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
+                <td colspan=2 > protectionDomainId </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The ID of the volume. </td>
+                <td> ID of the protection domain in which volume resides. </td>
             </tr>
-                                                                                                        </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > sizeInKb </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the volume in Kb. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the volume. </td>
+            </tr>
+                                        <tr>
+            <td colspan=3 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                                                                    </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -1,6 +1,6 @@
 **Ansible Modules for Dell Technologies PowerFlex** 
 =========================================
-### Release Notes 1.2.0
+### Release Notes 1.3.0
 
 >   © 2022 Dell Inc. or its subsidiaries. All rights reserved. Dell
 >   and other trademarks are trademarks of Dell Inc. or its
@@ -26,9 +26,9 @@ The table in this section lists the revision history of this document.
 
 Table 1. Revision history
 
-| Revision | Date      | Description                                               |
-|----------|-----------|-----------------------------------------------------------|
-| 01       | March 2022  | Current release of Ansible Modules for Dell PowerFlex 1.2.0 |
+| Revision | Date      | Description                                                 |
+|----------|-----------|-------------------------------------------------------------|
+| 01       | June 2022 | Current release of Ansible Modules for Dell PowerFlex 1.3.0 |
 
 Product Description
 -------------------
@@ -36,8 +36,8 @@ Product Description
 The Ansible modules for Dell PowerFlex are used to automate and orchestrate
 the deployment, configuration, and management of Dell PowerFlex storage
 systems. The capabilities of Ansible modules are managing volumes,
-storage pools, SDCs, snapshots, SDSs, devices, and protection domain, and
-obtaining high-level information about a PowerFlex system information.
+storage pools, SDCs, snapshots, SDSs, devices, protection domain and MDM 
+cluster, and obtaining high-level information about a PowerFlex system information.
 The modules use playbooks to list, show, create, delete, and modify
 each of the entities.
 
@@ -45,12 +45,16 @@ New Features and enhancements
 -----------------------------
 Along with the previous release deliverables, this release supports following features - 
 - The Product Guide, Release Notes and ReadMe have been updated to adhere to the guidelines by the ansible community.
-- Protection domain module supports following functionalities:
-  * Get protection domain details.
-  * Create a protection domain.
-  * Modify attributes of a protection domain.
-  * Delete a protection domain.
-- Names of previously released modules have been changed from dellemc_powerflex_\<module name> to \<module name>.
+- MDM cluster module supports following functionalities:
+  * Get MDM cluster details.
+  * Add a standby MDM.
+  * Remove a standby MDM.
+  * Modify attributes of an MDM.
+  * Change ownership of MDM cluster.
+  * Switch MDM cluster mode.
+  * Modify performance profile of MDM cluster.
+- Enabled the check_mode support for info module.
+- Added execution environment manifest file to support building an execution environment with ansible-builder.
 
 Known issues
 ------------
@@ -63,11 +67,11 @@ Limitations
 Distribution
 ------------
 The software package is available for download from the [Ansible Modules
-for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/1.2.0) page.
+for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/1.3.0) page.
 
 Documentation
 -------------
-The documentation is available on [Ansible Modules for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/1.2.0/docs)
+The documentation is available on [Ansible Modules for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/1.3.0/docs)
 page. It includes the following:
 
    - README

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,3 +1,4 @@
+---
 ### REQUIRED
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all
 # content lives. May only contain alphanumeric lowercase characters and underscores. Namespaces cannot start with
@@ -8,7 +9,7 @@ namespace: dellemc
 name: powerflex
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.0
+version: 1.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -24,7 +25,7 @@ authors:
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
-description: Ansible modules for Dell EMC PowerFlex
+description: Ansible modules for PowerFlex
 
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
@@ -47,13 +48,13 @@ tags: [storage]
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/dell/ansible-powerflex/tree/1.2.0
+repository: https://github.com/dell/ansible-powerflex/tree/1.3.0
 
 # The URL to any online docs
-documentation: https://github.com/dell/ansible-powerflex/tree/1.2.0/docs
+documentation: https://github.com/dell/ansible-powerflex/tree/1.3.0/docs
 
 # The URL to the homepage of the collection/project
-homepage: https://github.com/dell/ansible-powerflex/tree/1.2.0
+homepage: https://github.com/dell/ansible-powerflex/tree/1.3.0
 
 # The URL to the collection issue tracker
 issues: https://www.dell.com/community/Automation/bd-p/Automation

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,5 @@
+---
+version: 1
+dependencies:
+  galaxy: ../requirements.yml #Absolute/relative path of requirements.yml
+  python: ../requirements.txt #Absolute/relative path of requirements.txt

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,4 @@
+---
 requires_ansible: ">=2.10"
 plugin_routing:
     modules:

--- a/plugins/doc_fragments/powerflex.py
+++ b/plugins/doc_fragments/powerflex.py
@@ -1,23 +1,13 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2020, Dell EMC.
+# Copyright: (c) 2020, Dell Technologies.
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
 class ModuleDocFragment(object):
-
-    DOCUMENTATION = r'''
-options:
-  - See respective platform section for more details.
-requirements:
-  - See respective platform section for more details.
-notes:
-  - Ansible modules are available for Dell EMC PowerFlex Storage Platform.
-'''
-
     # Documentation fragment for PowerFlex
-    POWERFLEX = r'''
+    DOCUMENTATION = r'''
     options:
         gateway_host:
             required: True
@@ -59,9 +49,8 @@ notes:
             required: False
             default: 120
     requirements:
-      - A Dell EMC PowerFlex storage system version 3.5 and later.
-      - Ansible 2.10, 2.11 or 2.12
+      - A Dell PowerFlex storage system version 3.5 and later. Ansible 2.11, 2.12 or 2.13
     notes:
       - The modules present in the collection named as 'dellemc.powerflex'
-        are built to support the Dell EMC PowerFlex storage platform.
+        are built to support the Dell PowerFlex storage platform.
 '''

--- a/plugins/module_utils/storage/dell/logging_handler.py
+++ b/plugins/module_utils/storage/dell/logging_handler.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2022, DellEMC
+# Copyright: (c) 2022, Dell Technologies
 
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 

--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2021, DellEMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 from __future__ import absolute_import, division, print_function
 
@@ -7,7 +7,7 @@ __metaclass__ = type
 import logging
 import math
 from decimal import Decimal
-from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.dellemc_powerflex_logging_handler \
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.logging_handler \
     import CustomRotatingFileHandler
 
 """import PyPowerFlex lib"""
@@ -134,14 +134,14 @@ def pypowerflex_version_check():
             missing_packages += 'pkg_resources, '
 
         if not HAS_POWERFLEX_SDK:
-            missing_packages += 'PyPowerFlex V 1.3.0 or above'
+            missing_packages += 'PyPowerFlex V 1.4.0 or above'
         else:
-            min_ver = '1.3.0'
+            min_ver = '1.4.0'
             curr_version = pkg_resources.require("PyPowerFlex")[0].version
             supported_version = parse_version(curr_version) >= parse_version(
                 min_ver)
             if not supported_version:
-                missing_packages += 'PyPowerFlex V 1.3.0 or above'
+                missing_packages += 'PyPowerFlex V 1.4.0 or above'
 
         missing_packages_check = dict(
             dependency_present=False if missing_packages else True,

--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing device on PowerFlex"""
+""" Ansible module for managing device on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -11,14 +11,14 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: device
 version_added: '1.1.0'
-short_description: Manage device on Dell EMC PowerFlex
+short_description: Manage device on Dell PowerFlex
 description:
 - Managing device on PowerFlex storage system includes
   adding new device, getting details of device, and removing a device.
 author:
 - Rajshree Khare (@khareRajshree) <ansible.team@dell.com>
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 options:
   current_pathname:
     description:
@@ -425,7 +425,7 @@ device_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 LOG = utils.get_logger('device')
 
@@ -1043,6 +1043,11 @@ class PowerFlexDevice(object):
                     acceleration_pool_id=device_details[0][
                         'accelerationPoolId'])
                 device_details[0]['accelerationPoolName'] = ap_details['name']
+                pd_id = ap_details['protectionDomainId']
+                device_details[0]['protectionDomainId'] = pd_id
+                pd_details = self.get_protection_domain(
+                    protection_domain_id=pd_id)
+                device_details[0]['protectionDomainName'] = pd_details['name']
 
             return device_details[0]
 

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-"""Ansible module for Gathering information about Dell EMC PowerFlex"""
+"""Ansible module for Gathering information about Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -14,15 +14,15 @@ module: info
 
 version_added: '1.0.0'
 
-short_description: Gathering information about Dell EMC PowerFlex
+short_description: Gathering information about Dell PowerFlex
 
 description:
-- Gathering information about Dell EMC PowerFlex storage system includes
+- Gathering information about Dell PowerFlex storage system includes
   getting the api details, list of volumes, SDSs, SDCs, storage pools,
   protection domains, snapshot policies, and devices.
 
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 
 author:
 - Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -68,7 +68,7 @@ options:
         type: str
         required: True
 notes:
-  - The check_mode is not supported.
+  - The check_mode is supported.
 '''
 
 EXAMPLES = r'''
@@ -432,7 +432,7 @@ Devices:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 LOG = utils.get_logger('info')
 
@@ -456,7 +456,7 @@ class PowerFlexInfo(object):
 
         """ initialize the ansible module """
         self.module = AnsibleModule(argument_spec=self.module_params,
-                                    supports_check_mode=False)
+                                    supports_check_mode=True)
 
         if MISSING_PACKAGES_CHECK and \
                 not MISSING_PACKAGES_CHECK['dependency_present']:
@@ -468,6 +468,8 @@ class PowerFlexInfo(object):
             self.powerflex_conn = utils.get_powerflex_gateway_host_connection(
                 self.module.params)
             LOG.info('Got the PowerFlex system connection object instance')
+            LOG.info('The check_mode flag %s', self.module.check_mode)
+
         except Exception as e:
             LOG.error(str(e))
             self.module.fail_json(msg=str(e))

--- a/plugins/modules/mdm_cluster.py
+++ b/plugins/modules/mdm_cluster.py
@@ -1,0 +1,1338 @@
+#!/usr/bin/python
+# Copyright: (c) 2022, Dell Technologies
+# Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+""" Ansible module for managing MDM Cluster on PowerFlex"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: mdm_cluster
+version_added: '1.3.0'
+short_description: Manage MDM cluster on Dell PowerFlex
+description:
+- Managing MDM cluster and MDMs on PowerFlex storage system includes
+  adding/removing standby MDM, modify MDM name and virtual interface.
+- It also includes getting details of MDM cluster, modify MDM cluster
+  ownership, cluster mode, and performance profile.
+author:
+- Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
+extends_documentation_fragment:
+  - dellemc.powerflex.powerflex
+options:
+  mdm_name:
+    description:
+    - The name of the MDM. It is unique across the PowerFlex array.
+    - Mutually exclusive with mdm_id.
+    - If mdm_name passed in add standby operation, then same name will be
+      assigned to the new standby mdm.
+    type: str
+  mdm_id:
+    description:
+    - The ID of the MDM.
+    - Mutually exclusive with mdm_name.
+    type: str
+  mdm_new_name:
+    description:
+    - To rename the MDM.
+    type: str
+  standby_mdm:
+    description:
+    - Specifies add standby MDM parameters.
+    type: dict
+    suboptions:
+      mdm_ips:
+        description:
+        - List of MDM IPs that will be assigned to new MDM. It can contain
+          IPv4 addresses.
+        required: True
+        type: list
+        elements: str
+      role:
+        description:
+        - Role of new MDM.
+        required: True
+        choices: ['Manager', 'TieBreaker']
+        type: str
+      management_ips:
+        description:
+        - List of management IPs to manage MDM. It can contain IPv4
+          addresses.
+        type: list
+        elements: str
+      port:
+        description:
+        - Specifies the port of new MDM.
+        type: int
+      allow_multiple_ips:
+        description:
+        - Allow the added node to have different number of IPs from the
+          primary node.
+        type: bool
+      virtual_interfaces:
+        description:
+        - List of NIC interfaces that will be used for virtual IP addresses.
+        type: list
+        elements: str
+  is_primary:
+    description:
+    - Set is_primary as True to change MDM cluster ownership from the current
+      master MDM to different MDM.
+    - Set is_primary as False, will return MDM cluster details.
+    - New owner MDM must be an MDM with a manager role.
+    type: bool
+  cluster_mode:
+    description:
+    - Mode of the cluster.
+    choices: ['OneNode', 'ThreeNodes', 'FiveNodes']
+    type: str
+  mdm:
+    description:
+    - Specifies parameters to add/remove MDMs to/from the MDM cluster.
+    type: list
+    elements: dict
+    suboptions:
+      mdm_id:
+        description:
+        - ID of MDM that will be added/removed to/from the cluster.
+        type: str
+      mdm_name:
+        description:
+        - Name of MDM that will be added/removed to/from the cluster.
+        type: str
+      mdm_type:
+        description:
+        - Type of the MDM.
+        - Either mdm_id or mdm_name must be passed with mdm_type.
+        required: True
+        choices: ['Secondary', 'TieBreaker']
+        type: str
+  mdm_state:
+    description:
+    - Mapping state of MDM.
+    choices: ['present-in-cluster', 'absent-in-cluster']
+    type: str
+  virtual_ip_interfaces:
+    description:
+    - List of interfaces to be used for virtual IPs.
+    - The order of interfaces must be matched with virtual IPs assigned to the
+      cluster.
+    - Interfaces of the primary and secondary type MDMs are allowed to modify.
+    - The virtual_ip_interfaces is mutually exclusive with clear_interfaces.
+    type: list
+    elements: str
+  clear_interfaces:
+    description:
+    - Clear all virtual IP interfaces.
+    - The clear_interfaces is mutually exclusive with virtual_ip_interfaces.
+    type: bool
+  performance_profile:
+    description:
+    - Apply performance profile to cluster MDMs.
+    choices: ['Compact', 'HighPerformance']
+    type: str
+  state:
+    description:
+    - State of the MDM cluster.
+    choices: ['present', 'absent']
+    required: True
+    type: str
+notes:
+  - Parameters mdm_name or mdm_id are mandatory for rename and modify virtual IP
+    interfaces.
+  - Parameters mdm_name or mdm_id are not required while modifying performance
+    profile.
+  - For change MDM cluster ownership operation, only changed as True will be
+    returned and for idempotency case MDM cluster details will be returned.
+  - Reinstall all SDC after changing ownership to some newly added MDM.
+  - To add manager standby MDM, MDM package must be installed with manager
+    role.
+  - The check mode is supported.
+'''
+
+EXAMPLES = r'''
+- name: Add a standby MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    standby_mdm:
+      mdm_ips:
+        - "10.x.x.x"
+      role: "TieBreaker"
+      management_ips:
+        - "10.x.y.z"
+    state: "present"
+
+- name: Remove a standby MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    state: "absent"
+
+- name: Switch cluster mode from 3 node to 5 node MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    cluster_mode: "FiveNodes"
+    mdm:
+      - mdm_id: "5f091a8a013f1100"
+        mdm_type: "Secondary"
+      - mdm_name: "mdm_1"
+        mdm_type: "TieBreaker"
+    sdc_state: "present-in-cluster"
+    state: "present"
+
+- name: Switch cluster mode from 5 node to 3 node MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    cluster_mode: "ThreeNodes"
+    mdm:
+      - mdm_id: "5f091a8a013f1100"
+        mdm_type: "Secondary"
+      - mdm_name: "mdm_1"
+        mdm_type: "TieBreaker"
+    sdc_state: "absent-in-cluster"
+    state: "present"
+
+- name: Get the details of the MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    state: "present"
+
+- name: Change ownership of MDM cluster
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_2"
+    is_primary: True
+    state: "present"
+
+- name: Modify performance profile
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    performance_profile: "HighPerformance"
+    state: "present"
+
+- name: Rename the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    mdm_new_name: "new_mdm_1"
+    state: "present"
+
+- name: Modify virtual IP interface of the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    virtual_ip_interface:
+        - "ens224"
+    state: "present"
+
+- name: Clear virtual IP interface of the MDM
+  dellemc.powerflex.mdm_cluster:
+    gateway_host: "{{gateway_host}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    verifycert: "{{verifycert}}"
+    port: "{{port}}"
+    mdm_name: "mdm_1"
+    clear_interfaces: True
+    state: "present"
+'''
+
+RETURN = r'''
+changed:
+    description: Whether or not the resource has changed.
+    returned: always
+    type: bool
+    sample: 'false'
+mdm_cluster_details:
+    description: Details of the MDM cluster.
+    returned: When MDM cluster exists
+    type: complex
+    contains:
+        id:
+            description: The ID of the MDM cluster.
+            type: str
+        name:
+            description: Name of MDM cluster.
+            type: str
+        clusterMode:
+            description: Mode of the MDM cluster.
+            type: str
+        master:
+            description: The details of the master MDM.
+            type: complex
+            contains:
+                id:
+                    description: ID of the MDM.
+                    type: str
+                name:
+                    description: Name of the MDM.
+                    type: str
+                port:
+                    description: Port of the MDM.
+                    type: str
+                ips:
+                    description: List of IPs for master MDM.
+                    type: list
+                managementIPs:
+                    description: List of management IPs for master MDM.
+                    type: list
+                role:
+                    description: Role of MDM.
+                    type: str
+                status:
+                    description: Status of MDM.
+                    type: str
+                versionInfo:
+                    description: Version of MDM.
+                    type: str
+                virtualInterfaces:
+                    description: List of virtual interfaces
+                    type: list
+                opensslVersion:
+                    description: OpenSSL version.
+                    type: str
+        slaves:
+            description: The list of the secondary MDMs.
+            type: list
+            elements: dict
+            contains:
+                id:
+                    description: ID of the MDM.
+                    type: str
+                name:
+                    description: Name of the MDM.
+                    type: str
+                port:
+                    description: Port of the MDM.
+                    type: str
+                ips:
+                    description: List of IPs for secondary MDM.
+                    type: list
+                managementIPs:
+                    description: List of management IPs for secondary MDM.
+                    type: list
+                role:
+                    description: Role of MDM.
+                    type: str
+                status:
+                    description: Status of MDM.
+                    type: str
+                versionInfo:
+                    description: Version of MDM.
+                    type: str
+                virtualInterfaces:
+                    description: List of virtual interfaces
+                    type: list
+                opensslVersion:
+                    description: OpenSSL version.
+                    type: str
+        tieBreakers:
+            description: The list of the TieBreaker MDMs.
+            type: list
+            elements: dict
+            contains:
+                id:
+                    description: ID of the MDM.
+                    type: str
+                name:
+                    description: Name of the MDM.
+                    type: str
+                port:
+                    description: Port of the MDM.
+                    type: str
+                ips:
+                    description: List of IPs for tie-breaker MDM.
+                    type: list
+                managementIPs:
+                    description: List of management IPs for tie-breaker MDM.
+                    type: list
+                role:
+                    description: Role of MDM.
+                    type: str
+                status:
+                    description: Status of MDM.
+                    type: str
+                versionInfo:
+                    description: Version of MDM.
+                    type: str
+                opensslVersion:
+                    description: OpenSSL version.
+                    type: str
+        standbyMDMs:
+            description: The list of the standby MDMs.
+            type: list
+            elements: dict
+            contains:
+                id:
+                    description: ID of the MDM.
+                    type: str
+                name:
+                    description: Name of the MDM.
+                    type: str
+                port:
+                    description: Port of the MDM.
+                    type: str
+                ips:
+                    description: List of IPs for MDM.
+                    type: list
+                managementIPs:
+                    description: List of management IPs for MDM.
+                    type: list
+                role:
+                    description: Role of MDM.
+                    type: str
+                status:
+                    description: Status of MDM.
+                    type: str
+                versionInfo:
+                    description: Version of MDM.
+                    type: str
+                virtualInterfaces:
+                    description: List of virtual interfaces
+                    type: list
+                opensslVersion:
+                    description: OpenSSL version.
+                    type: str
+        clusterState:
+            description: State of the MDM cluster.
+            type: str
+        goodNodesNum:
+            description: Number of Nodes in MDM cluster.
+            type: int
+        goodReplicasNum:
+            description: Number of nodes for Replication.
+            type: int
+        virtualIps:
+            description: List of virtual IPs.
+            type: list
+    sample: {
+        "clusterState": "ClusteredNormal",
+        "clusterMode": "ThreeNodes",
+        "goodNodesNum": 3,
+        "master": {
+            "virtualInterfaces": [
+                "ens1"
+            ],
+            "managementIPs": [
+                "10.x.y.z"
+            ],
+            "ips": [
+                "10.x.y.z"
+            ],
+            "versionInfo": "R3_6.0.0",
+            "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+            "role": "Manager",
+            "status": "Normal",
+            "name": "sample_mdm",
+            "id": "5908d328581d1400",
+            "port": 9011
+        },
+        "perfProfile": "HighPerformance",
+        "slaves": [
+            {
+                "virtualInterfaces": [
+                    "ens1"
+                ],
+                "managementIPs": [
+                    "10.x.x.z"
+                ],
+                "ips": [
+                    "10.x.x.z"
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+                "role": "Manager",
+                "status": "Normal",
+                "name": "sample_mdm1",
+                "id": "5908d328581d1401",
+                "port": 9011
+            }
+        ],
+        "tieBreakers": [
+            {
+                "virtualInterfaces": [],
+                "managementIPs": [],
+                "ips": [
+                    "10.x.y.y"
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "id": "5908d328581d1402",
+                "port": 9011
+            }
+        ],
+        "standbyMDMs": [
+            {
+                "virtualInterfaces": [],
+                "managementIPs": [
+                    "10.x.z.z"
+                ],
+                "ips": [
+                    "10.x.z.z"
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "id": "5908d328581d1403",
+                "port": 9011
+            }
+        ],
+        "goodReplicasNum": 2,
+        "id": "cdd883cf00000002"
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
+    import utils
+import copy
+
+LOG = utils.get_logger('mdm_cluster')
+
+MISSING_PACKAGES_CHECK = utils.pypowerflex_version_check()
+
+
+class PowerFlexMdmCluster(object):
+    """Class with MDM cluster operations"""
+
+    def __init__(self):
+        """ Define all parameters required by this module"""
+        self.module_params = utils.get_powerflex_gateway_host_parameters()
+        self.module_params.update(get_powerflex_mdm_cluster_parameters())
+
+        mut_ex_args = [['mdm_name', 'mdm_id'],
+                       ['virtual_ip_interfaces', 'clear_interfaces']]
+
+        required_together_args = [['cluster_mode', 'mdm', 'mdm_state']]
+
+        # initialize the Ansible module
+        self.module = AnsibleModule(
+            argument_spec=self.module_params,
+            supports_check_mode=True,
+            mutually_exclusive=mut_ex_args,
+            required_together=required_together_args)
+
+        if MISSING_PACKAGES_CHECK and \
+                not MISSING_PACKAGES_CHECK['dependency_present']:
+            err_msg = MISSING_PACKAGES_CHECK['error_message']
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+        self.not_exist_msg = "MDM {0} does not exists in MDM cluster."
+        self.exist_msg = "MDM already exists in the MDM cluster"
+        try:
+            self.powerflex_conn = utils.get_powerflex_gateway_host_connection(
+                self.module.params)
+            LOG.info("Got the PowerFlex system connection object instance")
+            LOG.info('Check Mode Flag %s', self.module.check_mode)
+        except Exception as e:
+            LOG.error(str(e))
+            self.module.fail_json(msg=str(e))
+
+    def set_mdm_virtual_interface(self, mdm_id=None, mdm_name=None,
+                                  virtual_ip_interfaces=None,
+                                  clear_interfaces=None,
+                                  mdm_cluster_details=None):
+        """Modify the MDM virtual IP interface.
+        :param mdm_id: ID of MDM
+        :param mdm_name: Name of MDM
+        :param virtual_ip_interfaces: List of virtual IP interfaces
+        :param clear_interfaces: clear virtual IP interfaces of MDM.
+        :param mdm_cluster_details: Details of MDM cluster
+        :return: True if modification of virtual interface or clear operation
+                 successful
+        """
+
+        name_or_id = mdm_id if mdm_id else mdm_name
+        if mdm_name is None and mdm_id is None:
+            err_msg = "Please provide mdm_name/mdm_id to modify virtual IP" \
+                      " interfaces the MDM."
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+        mdm_details = self.\
+            is_mdm_name_id_exists(mdm_name=mdm_name, mdm_id=mdm_id,
+                                  cluster_details=mdm_cluster_details)
+        if mdm_details is None:
+            err_msg = self.not_exist_msg.format(name_or_id)
+            self.module.fail_json(msg=err_msg)
+
+        mdm_id = mdm_details['id']
+        modify_list = []
+        modify_list, clear = is_modify_mdm_virtual_interface(
+            virtual_ip_interfaces, clear_interfaces, mdm_details)
+
+        if modify_list is None and not clear:
+            LOG.info("No change required in MDM virtual IP interfaces.")
+            return False
+
+        try:
+            log_msg = "Modifying MDM virtual interfaces to %s " \
+                      "or %s" % (str(modify_list), clear)
+            LOG.info(log_msg)
+            if not self.module.check_mode:
+                self.powerflex_conn.system.modify_virtual_ip_interface(
+                    mdm_id=mdm_id, virtual_ip_interfaces=modify_list,
+                    clear_interfaces=clear)
+            return True
+        except Exception as e:
+            error_msg = "Failed to modify the virtual IP interfaces of MDM " \
+                        "{0} with error {1}".format(name_or_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def set_performance_profile(self, performance_profile=None,
+                                cluster_details=None):
+        """ Set the performance profile of Cluster MDMs
+        :param performance_profile: Specifies the performance profile of MDMs
+        :param cluster_details: Details of MDM cluster
+        :return: True if updated successfully
+        """
+
+        if self.module.params['state'] == 'present' and performance_profile:
+            if cluster_details['perfProfile'] != performance_profile:
+                try:
+                    if not self.module.check_mode:
+                        self.powerflex_conn.system.\
+                            set_cluster_mdm_performance_profile(performance_profile=performance_profile)
+                    return True
+                except Exception as e:
+                    error_msg = "Failed to update performance profile to {0} " \
+                                "with error {1}.".format(performance_profile,
+                                                         str(e))
+                    LOG.error(error_msg)
+                    self.module.fail_json(msg=error_msg)
+            return False
+        return False
+
+    def rename_mdm(self, mdm_name=None, mdm_id=None, mdm_new_name=None,
+                   cluster_details=None):
+        """Rename the MDM
+        :param mdm_name: Name of the MDM.
+        :param mdm_id: ID of the MDM.
+        :param mdm_new_name: New name of the MDM.
+        :param cluster_details: Details of the MDM cluster.
+        :return: True if successfully renamed.
+        """
+
+        name_or_id = mdm_id if mdm_id else mdm_name
+        if mdm_name is None and mdm_id is None:
+            err_msg = "Please provide mdm_name/mdm_id to rename the MDM."
+            self.module.fail_json(msg=err_msg)
+        mdm_details = self.\
+            is_mdm_name_id_exists(mdm_name=mdm_name, mdm_id=mdm_id,
+                                  cluster_details=cluster_details)
+        if mdm_details is None:
+            err_msg = self.not_exist_msg.format(name_or_id)
+            self.module.fail_json(msg=err_msg)
+
+        mdm_id = mdm_details['id']
+        try:
+            if ('name' in mdm_details and
+                mdm_new_name != mdm_details['name']) or \
+                    'name' not in mdm_details:
+                log_msg = "Modifying the MDM name from %s to " \
+                          "%s." % (mdm_name, mdm_new_name)
+                LOG.info(log_msg)
+                if not self.module.check_mode:
+                    self.powerflex_conn.system.rename_mdm(
+                        mdm_id=mdm_id, mdm_new_name=mdm_new_name)
+                return True
+        except Exception as e:
+            error_msg = "Failed to rename the MDM {0} with error {1}.".\
+                format(name_or_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def is_none_name_id_in_switch_cluster_mode(self, mdm):
+        """ Check whether mdm dict have mdm_name and mdm_id or not"""
+
+        for node in mdm:
+            if node['mdm_id'] and node['mdm_name']:
+                msg = "parameters are mutually exclusive: mdm_name|mdm_id"
+                self.module.fail_json(msg=msg)
+
+    def change_cluster_mode(self, cluster_mode, mdm, cluster_details):
+        """change the MDM cluster mode.
+        :param cluster_mode: specifies the mode of MDM cluster
+        :param mdm: A dict containing parameters to change MDM cluster mode
+        :param cluster_details: Details of MDM cluster
+        :return: True if mode changed successfully
+        """
+
+        self.is_none_name_id_in_switch_cluster_mode(mdm=mdm)
+
+        if cluster_mode == cluster_details['clusterMode']:
+            LOG.info("MDM cluster is already in required mode.")
+            return False
+
+        add_secondary = []
+        add_tb = []
+        remove_secondary = []
+        remove_tb = []
+        if self.module.params['state'] == 'present' and \
+                self.module.params['mdm_state'] == 'present-in-cluster':
+            add_secondary, add_tb = self.cluster_expand_list(mdm, cluster_details)
+        elif self.module.params['state'] == 'present' and \
+                self.module.params['mdm_state'] == 'absent-in-cluster':
+            remove_secondary, remove_tb = self.\
+                cluster_reduce_list(mdm, cluster_details)
+        try:
+            if not self.module.check_mode:
+                self.powerflex_conn.system.switch_cluster_mode(
+                    cluster_mode=cluster_mode, add_secondary=add_secondary,
+                    remove_secondary=remove_secondary, add_tb=add_tb,
+                    remove_tb=remove_tb)
+            return True
+        except Exception as e:
+            err_msg = "Failed to change the MDM cluster mode with error " \
+                      "{0}".format(str(e))
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+    def gather_secondarys_ids(self, mdm, cluster_details):
+        """ Prepare a list of secondary MDMs for switch cluster mode
+            operation"""
+
+        secondarys = []
+
+        for node in mdm:
+            name_or_id = node['mdm_name'] if node['mdm_name'] else \
+                node['mdm_id']
+
+            if node['mdm_type'] == 'Secondary' and node['mdm_id'] is not None:
+                mdm_details = self. \
+                    is_mdm_name_id_exists(mdm_id=node['mdm_id'],
+                                          cluster_details=cluster_details)
+                if mdm_details is None:
+                    err_msg = self.not_exist_msg.format(name_or_id)
+                    self.module.fail_json(msg=err_msg)
+                secondarys.append(node['mdm_id'])
+
+            elif node['mdm_type'] == 'Secondary' and node['mdm_name'] is not None:
+                mdm_details = self. \
+                    is_mdm_name_id_exists(mdm_name=node['mdm_name'],
+                                          cluster_details=cluster_details)
+                if mdm_details is None:
+                    err_msg = self.not_exist_msg.format(name_or_id)
+                    self.module.fail_json(msg=err_msg)
+                secondarys.append(mdm_details['id'])
+        return secondarys
+
+    def cluster_expand_list(self, mdm, cluster_details):
+        """Whether MDM cluster expansion is required or not.
+        """
+        add_secondary = []
+        add_tb = []
+
+        if 'standbyMDMs' not in cluster_details:
+            err_msg = "No Standby MDMs found. To expand cluster size, " \
+                      "first add standby MDMs."
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+        add_secondary = self.gather_secondarys_ids(mdm, cluster_details)
+        for node in mdm:
+            name_or_id = node['mdm_name'] if node['mdm_name'] else \
+                node['mdm_id']
+
+            if node['mdm_type'] == 'TieBreaker' and \
+                    node['mdm_id'] is not None:
+                add_tb.append(node['mdm_id'])
+
+            elif node['mdm_type'] == 'TieBreaker' and \
+                    node['mdm_name'] is not None:
+                mdm_details = self. \
+                    is_mdm_name_id_exists(mdm_name=node['mdm_name'],
+                                          cluster_details=cluster_details)
+
+                if mdm_details is None:
+                    err_msg = self.not_exist_msg.format(name_or_id)
+                    self.module.fail_json(msg=err_msg)
+                add_tb.append(mdm_details['id'])
+
+        log_msg = "expand List are: %s, %s" % (add_secondary, add_tb)
+        LOG.info(log_msg)
+        return add_secondary, add_tb
+
+    def cluster_reduce_list(self, mdm, cluster_details):
+        """Whether MDM cluster reduction is required or not.
+        """
+        remove_secondary = []
+        remove_tb = []
+
+        remove_secondary = self.gather_secondarys_ids(mdm, cluster_details)
+        for node in mdm:
+            name_or_id = node['mdm_name'] if node['mdm_name'] else \
+                node['mdm_id']
+
+            if node['mdm_type'] == 'TieBreaker' and \
+                    node['mdm_id'] is not None:
+                mdm_details = self. \
+                    is_mdm_name_id_exists(mdm_id=node['mdm_id'],
+                                          cluster_details=cluster_details)
+                if mdm_details is None:
+                    err_msg = self.not_exist_msg.format(name_or_id)
+                    self.module.fail_json(msg=err_msg)
+                remove_tb.append(mdm_details['id'])
+
+            elif node['mdm_type'] == 'TieBreaker' and \
+                    node['mdm_name'] is not None:
+                mdm_details = self.\
+                    is_mdm_name_id_exists(mdm_name=node['mdm_name'],
+                                          cluster_details=cluster_details)
+                if mdm_details is None:
+                    err_msg = self.not_exist_msg.format(name_or_id)
+                    self.module.fail_json(msg=err_msg)
+                remove_tb.append(mdm_details['id'])
+
+        log_msg = "Reduce List are: %s, %s." % (remove_secondary, remove_tb)
+        LOG.info(log_msg)
+        return remove_secondary, remove_tb
+
+    def perform_add_standby(self, mdm_name, standby_payload):
+        """ Perform SDK call to add a standby MDM
+
+        :param mdm_name: Name of new standby MDM
+        :param standby_payload: Parameters dict to add a standby MDM
+        :return: True if standby MDM added successfully
+        """
+        try:
+            if not self.module.check_mode:
+                self.powerflex_conn.system.add_standby_mdm(
+                    mdm_ips=standby_payload['mdm_ips'],
+                    role=standby_payload['role'],
+                    management_ips=standby_payload['management_ips'],
+                    mdm_name=mdm_name, port=standby_payload['port'],
+                    allow_multiple_ips=standby_payload['allow_multiple_ips'],
+                    virtual_interface=standby_payload['virtual_interfaces'])
+            return True
+        except Exception as e:
+            err_msg = "Failed to Add a standby MDM with error {0}.".format(
+                str(e))
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+    def is_id_new_name_in_add_mdm(self):
+        """ Check whether mdm_id or mdm_new_name present in Add standby MDM"""
+
+        if self.module.params['mdm_id'] or self.module.params['mdm_new_name']:
+            err_msg = "Parameters mdm_id/mdm_new_name are not allowed while" \
+                      " adding a standby MDM. Please try with valid " \
+                      "parameters to add a standby MDM."
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+    def add_standby_mdm(self, mdm_name, standby_mdm, cluster_details):
+        """ Adding a standby MDM"""
+
+        if self.module.params['state'] == 'present' and \
+                standby_mdm is not None and \
+                (self.check_mdm_exists(standby_mdm['mdm_ips'],
+                                       cluster_details)):
+            self.is_id_new_name_in_add_mdm()
+            mdm_details = self.\
+                is_mdm_name_id_exists(mdm_name=mdm_name,
+                                      cluster_details=cluster_details)
+            if mdm_details:
+                LOG.info("Standby MDM %s exits in the system", mdm_name)
+                return False, cluster_details
+
+            standby_payload = prepare_standby_payload(standby_mdm)
+            standby_add = self.perform_add_standby(mdm_name, standby_payload)
+
+            if standby_add:
+                cluster_details = self.get_mdm_cluster_details()
+                msg = "Fetched the MDM cluster details {0} after adding a " \
+                      "standby MDM".format(str(cluster_details))
+                LOG.info(msg)
+                return True, cluster_details
+        return False, cluster_details
+
+    def remove_standby_mdm(self, mdm_name, mdm_id, cluster_details):
+        """ Remove the Standby MDM
+        :param mdm_id: ID of MDM that will become owner of MDM cluster
+        :param mdm_name: Name of MDM that will become owner of MDM cluster
+        :param cluster_details: Details of MDM cluster
+        :return: True if MDM removed successful
+        """
+
+        name_or_id = mdm_id if mdm_id else mdm_name
+        if mdm_id is None and mdm_name is None:
+            err_msg = "Either mdm_name or mdm_id is required while removing" \
+                      " the standby MDM."
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+        mdm_details = self. \
+            is_mdm_name_id_exists(mdm_name=mdm_name, mdm_id=mdm_id,
+                                  cluster_details=cluster_details)
+        if mdm_details is None:
+            LOG.info("MDM %s not exists in MDM cluster.", name_or_id)
+            return False
+        mdm_id = mdm_details['id']
+
+        try:
+            if not self.module.check_mode:
+                self.powerflex_conn.system.remove_standby_mdm(mdm_id=mdm_id)
+            return True
+        except Exception as e:
+            error_msg = "Failed to remove the standby MDM {0} from the MDM " \
+                        "cluster with error {1}".format(name_or_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def change_ownership(self, mdm_id=None, mdm_name=None,
+                         cluster_details=None):
+        """ Change the ownership of MDM cluster.
+        :param mdm_id: ID of MDM that will become owner of MDM cluster
+        :param mdm_name: Name of MDM that will become owner of MDM cluster
+        :param cluster_details: Details of MDM cluster
+        :return: True if Owner of MDM cluster change successful
+        """
+
+        name_or_id = mdm_id if mdm_id else mdm_name
+        if mdm_id is None and mdm_name is None:
+            err_msg = "Either mdm_name or mdm_id is required while changing" \
+                      " ownership of MDM cluster."
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+        mdm_details = self.\
+            is_mdm_name_id_exists(mdm_name=mdm_name, mdm_id=mdm_id,
+                                  cluster_details=cluster_details)
+        if mdm_details is None:
+            err_msg = self.not_exist_msg.format(name_or_id)
+            self.module.fail_json(msg=err_msg)
+
+        mdm_id = mdm_details['id']
+
+        if mdm_details['id'] == cluster_details['master']['id']:
+            LOG.info("MDM %s is already Owner of MDM cluster.", name_or_id)
+            return False
+        else:
+            try:
+                if not self.module.check_mode:
+                    self.powerflex_conn.system.\
+                        change_mdm_ownership(mdm_id=mdm_id)
+                return True
+            except Exception as e:
+                error_msg = "Failed to update the Owner of MDM cluster to " \
+                            "MDM {0} with error {1}".format(name_or_id,
+                                                            str(e))
+                LOG.error(error_msg)
+                self.module.fail_json(msg=error_msg)
+
+    def find_mdm_in_secondarys(self, mdm_name=None, mdm_id=None,
+                               cluster_details=None, name_or_id=None):
+        """Whether MDM exists with mdm_name or id in secondary MDMs"""
+        for mdm in cluster_details['slaves']:
+            if ('name' in mdm and mdm_name == mdm['name']) or \
+                    mdm_id == mdm['id']:
+                LOG.info("MDM %s found in Secondarys MDM.", name_or_id)
+                return mdm
+
+    def find_mdm_in_tb(self, mdm_name=None, mdm_id=None,
+                       cluster_details=None, name_or_id=None):
+        """Whether MDM exists with mdm_name or id in tie-breaker MDMs"""
+
+        for mdm in cluster_details['tieBreakers']:
+            if ('name' in mdm and mdm_name == mdm['name']) or \
+                    mdm_id == mdm['id']:
+                LOG.info("MDM %s found in tieBreakers MDM.", name_or_id)
+                return mdm
+
+    def find_mdm_in_standby(self, mdm_name=None, mdm_id=None,
+                            cluster_details=None, name_or_id=None):
+        """Whether MDM exists with mdm_name or id in standby MDMs"""
+
+        if 'standbyMDMs' in cluster_details:
+            for mdm in cluster_details['standbyMDMs']:
+                if ('name' in mdm and mdm_name == mdm['name']) or \
+                        mdm_id == mdm['id']:
+                    LOG.info("MDM %s found in standby MDM.", name_or_id)
+                    return mdm
+
+    def is_mdm_name_id_exists(self, mdm_id=None, mdm_name=None,
+                              cluster_details=None):
+        """Whether MDM exists with mdm_name or id """
+
+        name_or_id = mdm_id if mdm_id else mdm_name
+        # check in master MDM
+        if ('name' in cluster_details['master'] and mdm_name == cluster_details['master']['name']) \
+                or mdm_id == cluster_details['master']['id']:
+            LOG.info("MDM %s is master MDM.", name_or_id)
+            return cluster_details['master']
+
+        # check in secondary MDMs
+        secondary_mdm = []
+        secondary_mdm = self.\
+            find_mdm_in_secondarys(mdm_name=mdm_name, mdm_id=mdm_id,
+                                   cluster_details=cluster_details,
+                                   name_or_id=name_or_id)
+        if secondary_mdm is not None:
+            return secondary_mdm
+
+        # check in tie-breaker MDMs
+        tb_mdm = []
+        tb_mdm = self.find_mdm_in_tb(mdm_name=mdm_name, mdm_id=mdm_id,
+                                     cluster_details=cluster_details,
+                                     name_or_id=name_or_id)
+        if tb_mdm is not None:
+            return tb_mdm
+
+        # check in standby MDMs
+        standby_mdm = self.find_mdm_in_standby(mdm_name=mdm_name,
+                                               mdm_id=mdm_id,
+                                               cluster_details=cluster_details,
+                                               name_or_id=name_or_id)
+        if standby_mdm is not None:
+            return standby_mdm
+
+        LOG.info("MDM %s does not exists in MDM Cluster.", name_or_id)
+        return None
+
+    def get_mdm_cluster_details(self):
+        """Get MDM cluster details
+        :return: Details of MDM Cluster if existed.
+        """
+
+        try:
+            mdm_cluster_details = self.powerflex_conn.system.\
+                get_mdm_cluster_details()
+
+            if len(mdm_cluster_details) == 0:
+                msg = "MDM cluster not found"
+                LOG.error(msg)
+                self.module.fail_json(msg=msg)
+
+            # Append Performance profile
+            resp = self.get_system_details()
+            if resp is not None:
+                mdm_cluster_details['perfProfile'] = resp['perfProfile']
+
+            return mdm_cluster_details
+
+        except Exception as e:
+            error_msg = "Failed to get the MDM cluster with error {0}."
+            error_msg = error_msg.format(str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def check_ip_in_secondarys(self, standby_ip, cluster_details):
+        """whether standby IPs present in secondary MDMs"""
+
+        for secondary_mdm in cluster_details['slaves']:
+            current_secondary_ips = secondary_mdm['ips']
+            for ips in standby_ip:
+                if ips in current_secondary_ips:
+                    LOG.info(self.exist_msg)
+                    return False
+        return True
+
+    def check_ip_in_tbs(self, standby_ip, cluster_details):
+        """whether standby IPs present in tie-breaker MDMs"""
+
+        for tb_mdm in cluster_details['tieBreakers']:
+            current_tb_ips = tb_mdm['ips']
+            for ips in standby_ip:
+                if ips in current_tb_ips:
+                    LOG.info(self.exist_msg)
+                    return False
+        return True
+
+    def check_ip_in_standby(self, standby_ip, cluster_details):
+        """whether standby IPs present in standby MDMs"""
+
+        if 'standbyMDMs' in cluster_details:
+            for stb_mdm in cluster_details['tieBreakers']:
+                current_stb_ips = stb_mdm['ips']
+                for ips in standby_ip:
+                    if ips in current_stb_ips:
+                        LOG.info(self.exist_msg)
+                        return False
+        return True
+
+    def check_mdm_exists(self, standby_ip=None, cluster_details=None):
+        """Check whether standby MDM exists in MDM Cluster"""
+
+        # check in master node
+        current_master_ips = cluster_details['master']['ips']
+        for ips in standby_ip:
+            if ips in current_master_ips:
+                LOG.info(self.exist_msg)
+                return False
+
+        # check in secondary nodes
+        in_secondary = self.check_ip_in_secondarys(standby_ip=standby_ip,
+                                                   cluster_details=cluster_details)
+        if not in_secondary:
+            return False
+
+        # check in tie-breaker nodes
+        in_tbs = self.check_ip_in_tbs(standby_ip=standby_ip,
+                                      cluster_details=cluster_details)
+        if not in_tbs:
+            return False
+
+        # check in Standby nodes
+        in_standby = self.check_ip_in_standby(standby_ip=standby_ip,
+                                              cluster_details=cluster_details)
+        if not in_standby:
+            return False
+
+        LOG.info("New Standby MDM does not exists in MDM cluster")
+        return True
+
+    def get_system_details(self):
+        """Get system details
+        :return: Details of PowerFlex system
+        """
+
+        try:
+            resp = self.powerflex_conn.system.get()
+            if len(resp) == 0:
+                self.module.fail_json(msg="No system exist on the given "
+                                          "host.")
+            if len(resp) > 1:
+                self.module.fail_json(msg="Multiple systems exist on the "
+                                          "given host.")
+            return resp[0]
+        except Exception as e:
+            msg = "Failed to get system id with error %s" % str(e)
+            LOG.error(msg)
+            self.module.fail_json(msg=msg)
+
+    def validate_parameters(self):
+        """Validate the input parameters"""
+
+        name_params = ['mdm_name', 'mdm_id', 'mdm_new_name']
+        msg = "Please provide the valid {0}"
+
+        for n_item in name_params:
+            if self.module.params[n_item] is not None and \
+                    (len(self.module.params[n_item].strip()) or
+                     self.module.params[n_item].count(" ") > 0) == 0:
+                err_msg = msg.format(n_item)
+                self.module.fail_json(msg=err_msg)
+
+    def perform_module_operation(self):
+        """
+        Perform different actions on MDM cluster based on parameters passed in
+        the playbook
+        """
+        mdm_name = self.module.params['mdm_name']
+        mdm_id = self.module.params['mdm_id']
+        mdm_new_name = self.module.params['mdm_new_name']
+        standby_mdm = copy.deepcopy(self.module.params['standby_mdm'])
+        is_primary = self.module.params['is_primary']
+        cluster_mode = self.module.params['cluster_mode']
+        mdm = copy.deepcopy(self.module.params['mdm'])
+        mdm_state = self.module.params['mdm_state']
+        virtual_ip_interfaces = self.module.params['virtual_ip_interfaces']
+        clear_interfaces = self.module.params['clear_interfaces']
+        performance_profile = self.module.params['performance_profile']
+        state = self.module.params['state']
+
+        # result is a dictionary to contain end state and MDM cluster details
+        changed = False
+        result = dict(
+            changed=False,
+            mdm_cluster_details={}
+        )
+        self.validate_parameters()
+
+        mdm_cluster_details = self.get_mdm_cluster_details()
+        msg = "Fetched the MDM cluster details {0}".\
+            format(str(mdm_cluster_details))
+        LOG.info(msg)
+
+        standby_changed = False
+        performance_changed = False
+        renamed_changed = False
+        interface_changed = False
+        remove_changed = False
+        mode_changed = False
+        owner_changed = False
+
+        # Add standby MDM
+        standby_changed, mdm_cluster_details = self.\
+            add_standby_mdm(mdm_name, standby_mdm, mdm_cluster_details)
+
+        # Update performance profile
+        performance_changed = self.\
+            set_performance_profile(performance_profile, mdm_cluster_details)
+
+        # Rename MDM
+        if state == 'present' and mdm_new_name:
+            renamed_changed = self.rename_mdm(mdm_name, mdm_id, mdm_new_name,
+                                              mdm_cluster_details)
+
+        # Change MDM virtual IP interfaces
+        if state == 'present' and (virtual_ip_interfaces or clear_interfaces):
+            interface_changed = self.\
+                set_mdm_virtual_interface(mdm_id, mdm_name,
+                                          virtual_ip_interfaces,
+                                          clear_interfaces,
+                                          mdm_cluster_details)
+        # change cluster mode
+        if state == 'present' and cluster_mode and mdm and mdm_state:
+            mode_changed = self.change_cluster_mode(cluster_mode, mdm,
+                                                    mdm_cluster_details)
+
+        # Remove standby MDM
+        if state == 'absent':
+            remove_changed = self.remove_standby_mdm(mdm_name, mdm_id,
+                                                     mdm_cluster_details)
+
+        # change ownership of MDM cluster
+        if state == 'present' and is_primary:
+            owner_changed = self.change_ownership(mdm_id, mdm_name,
+                                                  mdm_cluster_details)
+
+        # Setting Changed Flag
+        changed = update_change_flag(standby_changed, performance_changed,
+                                     renamed_changed, interface_changed,
+                                     mode_changed, remove_changed,
+                                     owner_changed)
+
+        # Returning the updated MDM cluster details
+        # Checking whether owner of MDM cluster has changed
+        if owner_changed:
+            mdm_cluster_details = {}
+        else:
+            mdm_cluster_details = self.get_mdm_cluster_details()
+
+        result['mdm_cluster_details'] = mdm_cluster_details
+        result['changed'] = changed
+        self.module.exit_json(**result)
+
+
+def update_change_flag(standby_changed, performance_changed, renamed_changed,
+                       interface_changed, mode_changed, remove_changed,
+                       owner_changed):
+    """ Update the changed flag based on the operation performed in the task"""
+
+    if standby_changed or performance_changed or renamed_changed or \
+            interface_changed or mode_changed or remove_changed or \
+            owner_changed:
+        return True
+    return False
+
+
+def prepare_standby_payload(standby_mdm):
+    """prepare the payload for add standby MDM"""
+    payload_dict = {}
+    for mdm_keys in standby_mdm:
+        if standby_mdm[mdm_keys]:
+            payload_dict[mdm_keys] = standby_mdm[mdm_keys]
+        else:
+            payload_dict[mdm_keys] = None
+    return payload_dict
+
+
+def is_modify_mdm_virtual_interface(virtual_ip_interfaces, clear_interfaces,
+                                    mdm_details):
+    """Check if modification in MDM virtual IP interface required."""
+
+    modify_list = []
+    clear = False
+    existing_interfaces = mdm_details['virtualInterfaces']
+
+    # Idempotency check for virtual IP interface
+    if clear_interfaces is None and \
+            len(existing_interfaces) == len(virtual_ip_interfaces) and \
+            set(existing_interfaces) == set(virtual_ip_interfaces):
+        LOG.info("No changes required for virtual IP interface.")
+        return None, False
+
+    # Idempotency check for clear_interfaces
+    if clear_interfaces and len(mdm_details['virtualInterfaces']) == 0:
+        LOG.info("No change required for clear interface.")
+        return None, False
+
+    # clearing all virtual IP interfaces of MDM
+    elif clear_interfaces and len(mdm_details['virtualInterfaces']) != 0 and \
+            virtual_ip_interfaces is None:
+        LOG.info("Clear all interfaces of the MDM.")
+        clear = True
+        return None, clear
+
+    if virtual_ip_interfaces and clear_interfaces is None:
+        for interface in virtual_ip_interfaces:
+            modify_list.append(interface)
+        return modify_list, clear
+
+
+def get_powerflex_mdm_cluster_parameters():
+    """This method provide parameter required for the MDM cluster
+    module on PowerFlex"""
+    return dict(
+        mdm_name=dict(), mdm_id=dict(), mdm_new_name=dict(),
+        virtual_ip_interfaces=dict(type='list', elements='str'),
+        clear_interfaces=dict(type='bool'), is_primary=dict(type='bool'),
+        standby_mdm=dict(type='dict', options=dict(
+            mdm_ips=dict(type='list', elements='str', required=True),
+            role=dict(required=True, choices=['Manager', 'TieBreaker']),
+            management_ips=dict(type='list', elements='str'),
+            port=dict(type='int'), allow_multiple_ips=dict(type='bool'),
+            virtual_interfaces=dict(type='list', elements='str'))),
+        cluster_mode=dict(choices=['OneNode', 'ThreeNodes', 'FiveNodes']),
+        mdm=dict(type='list', elements='dict',
+                 options=dict(mdm_id=dict(), mdm_name=dict(),
+                              mdm_type=dict(required=True,
+                                            choices=['Secondary', 'TieBreaker']))),
+        mdm_state=dict(choices=['present-in-cluster', 'absent-in-cluster']),
+        performance_profile=dict(choices=['Compact', 'HighPerformance']),
+        state=dict(required=True, type='str', choices=['present', 'absent'])
+    )
+
+
+def main():
+    """ Perform actions on MDM cluster based on user input from playbook"""
+    obj = PowerFlexMdmCluster()
+    obj.perform_module_operation()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/protection_domain.py
+++ b/plugins/modules/protection_domain.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2022, Dell EMC
+# Copyright: (c) 2022, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing Protection Domain on PowerFlex"""
+""" Ansible module for managing Protection Domain on Dell Technologies (Dell) PowerFlex"""
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
@@ -10,14 +10,14 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: protection_domain
 version_added: '1.2.0'
-short_description: Manage Protection Domain on Dell EMC PowerFlex
+short_description: Manage Protection Domain on Dell PowerFlex
 description:
 - Managing Protection Domain on PowerFlex storage system includes creating,
   modifying attributes, deleting and getting details of Protection Domain.
 author:
 - Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 options:
   protection_domain_name:
     description:
@@ -487,7 +487,7 @@ protection_domain_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 LOG = utils.get_logger('protection_domain')
 

--- a/plugins/modules/sdc.py
+++ b/plugins/modules/sdc.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing SDCs on PowerFlex"""
+""" Ansible module for managing SDCs on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: sdc
 version_added: '1.0.0'
-short_description: Manage SDCs on Dell EMC PowerFlex
+short_description: Manage SDCs on Dell PowerFlex
 description:
 - Managing SDCs on PowerFlex storage system includes getting details of SDC
   and renaming SDC.
@@ -20,7 +20,7 @@ author:
 - Akash Shendge (@shenda1) <ansible.team@dell.com>
 
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 
 options:
   sdc_name:
@@ -165,7 +165,7 @@ sdc_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 LOG = utils.get_logger('sdc')
 

--- a/plugins/modules/sds.py
+++ b/plugins/modules/sds.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing SDS on PowerFlex"""
+""" Ansible module for managing SDS on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: sds
 version_added: '1.1.0'
-short_description: Manage SDS on Dell EMC PowerFlex
+short_description: Manage SDS on Dell PowerFlex
 description:
 - Managing SDS on PowerFlex storage system includes
   creating new SDS, getting details of SDS, adding/removing IP to/from SDS,
@@ -19,7 +19,7 @@ description:
 author:
 - Rajshree Khare (@khareRajshree) <ansible.team@dell.com>
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 options:
   sds_name:
     description:
@@ -477,7 +477,7 @@ sds_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 import copy
 
 LOG = utils.get_logger('sds')

--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing Snapshots on PowerFlex"""
+""" Ansible module for managing Snapshots on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: snapshot
 version_added: '1.0.0'
-short_description: Manage Snapshots on Dell EMC PowerFlex
+short_description: Manage Snapshots on Dell PowerFlex
 description:
 - Managing snapshots on PowerFlex Storage System includes
   creating, getting details, mapping/unmapping to/from SDC,
@@ -21,7 +21,7 @@ author:
 - Akash Shendge (@shenda1) <ansible.team@dell.com>
 
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 
 options:
   snapshot_name:
@@ -367,7 +367,7 @@ snapshot_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 from datetime import datetime, timedelta
 import time
 import copy

--- a/plugins/modules/storagepool.py
+++ b/plugins/modules/storagepool.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-"""Ansible module for managing Dell EMC PowerFlex storage pool"""
+"""Ansible module for managing Dell Technologies (Dell) PowerFlex storage pool"""
 
 from __future__ import absolute_import, division, print_function
 
@@ -14,16 +14,15 @@ module: storagepool
 
 version_added: '1.0.0'
 
-short_description: Managing Dell EMC PowerFlex storage pool
+short_description: Managing Dell PowerFlex storage pool
 
 description:
-- Dell EMC PowerFlex storage pool module includes
-  getting the details of storage pool,
-  creating a new storage pool, and
-  modifying the attribute of a storage pool.
+- Dell PowerFlex storage pool module includes getting the details of
+  storage pool, creating a new storage pool, and modifying the attribute of
+  a storage pool.
 
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 
 author:
 - Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -282,7 +281,7 @@ storage_pool_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 LOG = utils.get_logger('storagepool')
 

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
-# Copyright: (c) 2021, Dell EMC
+# Copyright: (c) 2021, Dell Technologies
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-""" Ansible module for managing volumes on PowerFlex"""
+""" Ansible module for managing volumes on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -11,7 +11,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: volume
 version_added: '1.0.0'
-short_description: Manage volumes on Dell EMC PowerFlex
+short_description: Manage volumes on Dell PowerFlex
 description:
 - Managing volumes on PowerFlex storage system includes
   creating, getting details, modifying attributes and deleting volume.
@@ -21,7 +21,7 @@ description:
 author:
 - P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
 extends_documentation_fragment:
-  - dellemc.powerflex.dellemc_powerflex.powerflex
+  - dellemc.powerflex.powerflex
 options:
   vol_name:
     description:
@@ -482,7 +482,7 @@ volume_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 import copy
 
 LOG = utils.get_logger('volume')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+PyPowerFlex
+requests>=2.23.0
 python-dateutil>=2.8.0
 setuptools

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: dellemc.powerflex

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-xdist
-mock
 pytest-mock
 pytest-cov
 coverage==4.5.4
+mock

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -6,3 +6,4 @@ plugins/modules/storagepool.py validate-modules:missing-gplv3-license
 plugins/modules/volume.py validate-modules:missing-gplv3-license
 plugins/modules/info.py validate-modules:missing-gplv3-license
 plugins/modules/protection_domain.py validate-modules:missing-gplv3-license
+plugins/modules/mdm_cluster.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -6,3 +6,4 @@ plugins/modules/storagepool.py validate-modules:missing-gplv3-license
 plugins/modules/volume.py validate-modules:missing-gplv3-license
 plugins/modules/info.py validate-modules:missing-gplv3-license
 plugins/modules/protection_domain.py validate-modules:missing-gplv3-license
+plugins/modules/mdm_cluster.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -6,3 +6,4 @@ plugins/modules/storagepool.py validate-modules:missing-gplv3-license
 plugins/modules/volume.py validate-modules:missing-gplv3-license
 plugins/modules/info.py validate-modules:missing-gplv3-license
 plugins/modules/protection_domain.py validate-modules:missing-gplv3-license
+plugins/modules/mdm_cluster.py validate-modules:missing-gplv3-license

--- a/tests/unit/plugins/module_utils/mock_api_exception.py
+++ b/tests/unit/plugins/module_utils/mock_api_exception.py
@@ -1,16 +1,12 @@
-# Copyright: (c) 2022, DellEMC
+# Copyright: (c) 2022, Dell Technologies
 
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-"""Mock ApiException for PowerFlex Test modules"""
+"""Mock ApiException for Dell Technologies (Dell) PowerFlex Test modules"""
 
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'
-                    }
 
 
 class MockApiException(Exception):

--- a/tests/unit/plugins/module_utils/mock_mdm_cluster_api.py
+++ b/tests/unit/plugins/module_utils/mock_mdm_cluster_api.py
@@ -1,0 +1,403 @@
+# Copyright: (c) 2022, Dell Technologies
+
+# Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+"""
+Mock Api response for Unit tests of MDM cluster module on PowerFlex
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+
+class MockMdmClusterApi:
+    MODULE_PATH = 'ansible_collections.dellemc.powerflex.plugins.modules.mdm_cluster.PowerFlexMdmCluster'
+    MODULE_UTILS_PATH = 'ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.utils'
+
+    MDM_CLUSTER_COMMON_ARGS = {
+        "gateway_host": "**.***.**.***",
+        "mdm_id": None,
+        "mdm_name": None,
+        "mdm_new_name": None,
+        "performance_profile": None,
+        "standby_mdm": None,
+        "is_primary": None,
+        "cluster_mode": None,
+        "mdm": None,
+        "mdm_state": None,
+        "virtual_ip_interfaces": None,
+        "clear_interfaces": None,
+        'state': None
+    }
+
+    MDM_NAME = "mdm_node1"
+    MDM_NAME_STB_MGR = "mdm_node_mgr"
+    MDM_ID = "5908d328581d1401"
+    STB_TB_MDM_ID = "5908d328581d1403"
+    STB_MGR_MDM_ID = "36279b98215e5a04"
+    IP_1 = "10.x.y.z"
+    IP_2 = "10.x.x.z"
+    IP_3 = "10.x.z.z"
+    IP_4 = "10.x.y.y"
+    SSL_VERSION = "OpenSSL 1.0.2k-fips  26 Jan 2017"
+    SYS_VERSION = "DellEMC PowerFlex Version: R3_6.0.354"
+
+    THREE_MDM_CLUSTER_DETAILS = {
+        "clusterState": "ClusteredNormal",
+        "clusterMode": "ThreeNodes",
+        "goodNodesNum": 3,
+        "master": {
+            "virtualInterfaces": [
+                "ens1"
+            ],
+            "managementIPs": [
+                IP_1
+            ],
+            "ips": [
+                IP_1
+            ],
+            "versionInfo": "R3_6.0.0",
+            "opensslVersion": SSL_VERSION,
+            "role": "Manager",
+            "status": "Normal",
+            "name": "sample_mdm",
+            "id": "5908d328581d1400",
+            "port": 9011
+        },
+        "perfProfile": "HighPerformance",
+        "slaves": [
+            {
+                "virtualInterfaces": [
+                    "ens1"
+                ],
+                "managementIPs": [
+                    IP_2
+                ],
+                "ips": [
+                    IP_2
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": SSL_VERSION,
+                "role": "Manager",
+                "status": "Normal",
+                "name": "sample_mdm1",
+                "id": MDM_ID,
+                "port": 9011
+            }
+        ],
+        "tieBreakers": [
+            {
+                "managementIPs": [],
+                "ips": [
+                    IP_4
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "id": "5908d328581d1402",
+                "port": 9011
+            }
+        ],
+        "standbyMDMs": [
+            {
+                "managementIPs": [
+                    IP_3
+                ],
+                "ips": [
+                    IP_3
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "name": MDM_NAME,
+                "id": STB_TB_MDM_ID,
+                "port": 9011
+            },
+            {
+                "virtualInterfaces": [
+                    "ens12"
+                ],
+                "managementIPs": [
+                    IP_3
+                ],
+                "ips": [
+                    IP_3
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "Manager",
+                "status": "Normal",
+                "name": MDM_NAME_STB_MGR,
+                "id": STB_MGR_MDM_ID,
+                "port": 9011
+            }
+        ],
+        "goodReplicasNum": 2,
+        "id": "cdd883cf00000002"
+    }
+
+    THREE_MDM_CLUSTER_DETAILS_2 = {
+        "clusterState": "ClusteredNormal",
+        "clusterMode": "ThreeNodes",
+        "goodNodesNum": 3,
+        "master": {
+            "virtualInterfaces": [
+                "ens1"
+            ],
+            "managementIPs": [
+                IP_1
+            ],
+            "ips": [
+                IP_1
+            ],
+            "versionInfo": "R3_6.0.0",
+            "opensslVersion": SSL_VERSION,
+            "role": "Manager",
+            "status": "Normal",
+            "name": "sample_mdm",
+            "id": "5908d328581d1400",
+            "port": 9011
+        },
+        "perfProfile": "HighPerformance",
+        "slaves": [
+            {
+                "virtualInterfaces": [
+                    "ens1"
+                ],
+                "managementIPs": [
+                    IP_2
+                ],
+                "ips": [
+                    IP_2
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": SSL_VERSION,
+                "role": "Manager",
+                "status": "Normal",
+                "name": "sample_mdm1",
+                "id": MDM_ID,
+                "port": 9011
+            }
+        ],
+        "tieBreakers": [
+            {
+                "managementIPs": [],
+                "ips": [
+                    IP_4
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "id": "5908d328581d1402",
+                "port": 9011
+            }
+        ],
+        "goodReplicasNum": 2,
+        "id": "cdd883cf00000002"
+    }
+
+    FIVE_MDM_CLUSTER_DETAILS = {
+        "clusterState": "ClusteredNormal",
+        "clusterMode": "FiveNodes",
+        "goodNodesNum": 5,
+        "master": {
+            "virtualInterfaces": [
+                "ens1"
+            ],
+            "managementIPs": [
+                IP_1
+            ],
+            "ips": [
+                IP_1
+            ],
+            "versionInfo": "R3_6.0.0",
+            "opensslVersion": SSL_VERSION,
+            "role": "Manager",
+            "status": "Normal",
+            "name": "sample_mdm",
+            "id": "5908d328581d1400",
+            "port": 9011
+        },
+        "perfProfile": "HighPerformance",
+        "slaves": [
+            {
+                "virtualInterfaces": [],
+                "managementIPs": [
+                    IP_2
+                ],
+                "ips": [
+                    IP_2
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": SSL_VERSION,
+                "role": "Manager",
+                "status": "Normal",
+                "name": "sample_mdm11",
+                "id": MDM_ID,
+                "port": 9011
+            },
+            {
+                "virtualInterfaces": [
+                    "ens12"
+                ],
+                "managementIPs": [
+                    IP_3
+                ],
+                "ips": [
+                    IP_3
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "Manager",
+                "status": "Normal",
+                "name": MDM_NAME_STB_MGR,
+                "id": STB_MGR_MDM_ID,
+                "port": 9011
+            }
+        ],
+        "tieBreakers": [
+            {
+                "managementIPs": [
+                    IP_3
+                ],
+                "ips": [
+                    IP_3
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "name": MDM_NAME,
+                "id": STB_TB_MDM_ID,
+                "port": 9011
+            },
+            {
+                "managementIPs": [],
+                "ips": [
+                    IP_4
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "TieBreaker",
+                "status": "Normal",
+                "id": "5908d328581d1402",
+                "port": 9011
+            }
+        ],
+        "standbyMDMs": [
+            {
+                "virtualInterfaces": [
+                    "ens13"
+                ],
+                "managementIPs": [
+                    IP_1
+                ],
+                "ips": [
+                    IP_1
+                ],
+                "versionInfo": "R3_6.0.0",
+                "opensslVersion": "N/A",
+                "role": "Manager",
+                "status": "Normal",
+                "name": "mgr_node_2",
+                "id": "5120af354fb17305",
+                "port": 9011
+            }
+        ],
+        "goodReplicasNum": 2,
+        "id": "cdd883cf00000002"
+    }
+    PARTIAL_SYSTEM_DETAILS = [
+        {
+            "systemVersionName": SYS_VERSION,
+            "perfProfile": "Compact",
+            "name": "System:3c567fd2298f020f",
+            "id": "3c567fd2298f020f"
+        },
+        {
+            "systemVersionName": SYS_VERSION,
+            "perfProfile": "Compact",
+            "name": "System:3c567fd2298f0201",
+            "id": "3c567fd2298f0201"
+        }
+    ]
+    PARTIAL_SYSTEM_DETAILS_1 = [
+        {
+            "systemVersionName": SYS_VERSION,
+            "perfProfile": "Compact",
+            "name": "System:3c567fd2298f020f",
+            "id": "3c567fd2298f020f"
+        }
+    ]
+
+    @staticmethod
+    def get_failed_response():
+        return "Failed to get the MDM cluster with error"
+
+    @staticmethod
+    def rename_failed_response():
+        return "Failed to rename the MDM mdm_node1 with error"
+
+    @staticmethod
+    def perf_profile_failed_response():
+        return "Failed to update performance profile to Compact with error"
+
+    @staticmethod
+    def virtual_ip_interface_failed_response():
+        return "Failed to modify the virtual IP interfaces of MDM 5908d328581d1401 with error"
+
+    @staticmethod
+    def remove_mdm_failed_response():
+        return "Failed to remove the standby MDM 5908d328581d1403 from the MDM cluster with error"
+
+    @staticmethod
+    def add_mdm_failed_response():
+        return "Failed to Add a standby MDM with error"
+
+    @staticmethod
+    def owner_failed_response():
+        return "Failed to update the Owner of MDM cluster to MDM sample_mdm1 with error"
+
+    @staticmethod
+    def switch_mode_failed_response():
+        return "Failed to change the MDM cluster mode with error"
+
+    @staticmethod
+    def system_failed_response():
+        return "Failed to get system id with error"
+
+    @staticmethod
+    def multiple_system_failed_response():
+        return "Multiple systems exist on the given host."
+
+    @staticmethod
+    def remove_mdm_no_id_name_failed_response():
+        return "Either mdm_name or mdm_id is required while removing the standby MDM."
+
+    @staticmethod
+    def without_standby_failed_response():
+        return "No Standby MDMs found. To expand cluster size, first add standby MDMs."
+
+    @staticmethod
+    def no_cluster_failed_response():
+        return "MDM cluster not found"
+
+    @staticmethod
+    def id_none_interface_failed_response():
+        return "Please provide mdm_name/mdm_id to modify virtual IP interfaces the MDM"
+
+    @staticmethod
+    def id_none_rename_failed_response():
+        return "Please provide mdm_name/mdm_id to rename the MDM"
+
+    @staticmethod
+    def id_none_change_owner_failed_response():
+        return "Either mdm_name or mdm_id is required while changing ownership of MDM cluster"
+
+    @staticmethod
+    def new_name_add_mdm_failed_response():
+        return "Parameters mdm_id/mdm_new_name are not allowed while adding a standby MDM"

--- a/tests/unit/plugins/module_utils/mock_protection_domain_api.py
+++ b/tests/unit/plugins/module_utils/mock_protection_domain_api.py
@@ -1,23 +1,19 @@
-# Copyright: (c) 2022, DellEMC
+# Copyright: (c) 2022, Dell Technologies
 
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 """
-Mock Api response for Unit tests of protection domain module on PowerFlex
+Mock Api response for Unit tests of protection domain module on Dell Technologies (Dell) PowerFlex
 """
 
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'
-                    }
 
 
 class MockProtectionDomainApi:
     MODULE_PATH = 'ansible_collections.dellemc.powerflex.plugins.modules.protection_domain.PowerFlexProtectionDomain'
-    MODULE_UTILS_PATH = 'ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.dellemc_ansible_powerflex_utils'
+    MODULE_UTILS_PATH = 'ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.utils'
 
     PROTECTION_DOMAIN = {
         "protectiondomain": [

--- a/tests/unit/plugins/module_utils/mock_sdk_response.py
+++ b/tests/unit/plugins/module_utils/mock_sdk_response.py
@@ -1,16 +1,12 @@
-# Copyright: (c) 2022, DellEMC
+# Copyright: (c) 2022, Dell Technologies
 
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-"""Mock SDKResponse for Unit tests for PowerFlex modules"""
+"""Mock SDKResponse for Unit tests for Dell Technologies (Dell) PowerFlex modules"""
 
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'
-                    }
 
 
 class MockSDKResponse:

--- a/tests/unit/plugins/modules/test_mdm_cluster.py
+++ b/tests/unit/plugins/modules/test_mdm_cluster.py
@@ -1,0 +1,636 @@
+# Copyright: (c) 2022, Dell Technologies
+
+# Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+"""Unit Tests for MDM cluster module on PowerFlex"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import pytest
+from mock.mock import MagicMock
+from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_mdm_cluster_api import MockMdmClusterApi
+from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_sdk_response \
+    import MockSDKResponse
+from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_api_exception \
+    import MockApiException
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
+    import utils
+
+utils.get_logger = MagicMock()
+utils.get_powerflex_gateway_host_connection = MagicMock()
+utils.PowerFlexClient = MagicMock()
+from ansible.module_utils import basic
+basic.AnsibleModule = MagicMock()
+from ansible_collections.dellemc.powerflex.plugins.modules.mdm_cluster import PowerFlexMdmCluster
+
+
+class TestPowerflexProtectionDomain():
+
+    get_module_args = MockMdmClusterApi.MDM_CLUSTER_COMMON_ARGS
+    add_mdm_ip = "xx.3x.xx.xx"
+
+    @pytest.fixture
+    def mdm_cluster_module_mock(self, mocker):
+        mocker.patch(MockMdmClusterApi.MODULE_UTILS_PATH + '.PowerFlexClient', new=MockApiException)
+        mdm_cluster_module_mock = PowerFlexMdmCluster()
+        mdm_cluster_module_mock.module.check_mode = False
+        return mdm_cluster_module_mock
+
+    def test_get_mdm_cluster(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details.assert_called()
+
+    def test_get_mdm_cluster_with_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.get_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details.assert_called()
+
+    def test_rename_mdm(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": MockMdmClusterApi.MDM_NAME,
+            "mdm_new_name": "mdm_node_renamed",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.rename_mdm = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.rename_mdm.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_rename_mdm_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": MockMdmClusterApi.MDM_NAME,
+            "mdm_new_name": "mdm_node_renamed",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.rename_mdm = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.rename_mdm.assert_called()
+        assert MockMdmClusterApi.rename_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_set_performance_profile_mdm_cluster(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "performance_profile": "Compact",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.set_cluster_mdm_performance_profile = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.set_cluster_mdm_performance_profile.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_set_performance_profile_mdm_cluster_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "performance_profile": "Compact",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.set_cluster_mdm_performance_profile = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.set_cluster_mdm_performance_profile.assert_called()
+        assert MockMdmClusterApi.perf_profile_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_set_virtual_ip_interface_mdm(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.MDM_ID,
+            "virtual_ip_interfaces": ["ens11"],
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_set_virtual_ip_interface_mdm_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.MDM_ID,
+            "virtual_ip_interfaces": ["ens11"],
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface.assert_called()
+        assert MockMdmClusterApi.virtual_ip_interface_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_set_virtual_ip_interface_mdm_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.MDM_ID,
+            "virtual_ip_interfaces": ["ens1"],
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_remove_standby_mdm(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.STB_TB_MDM_ID,
+            "state": "absent"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.remove_standby_mdm = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.remove_standby_mdm.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_remove_standby_mdm_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "non_existing_node",
+            "state": "absent"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_remove_standby_mdm_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.STB_TB_MDM_ID,
+            "state": "absent"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.remove_standby_mdm = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.remove_standby_mdm.assert_called()
+        assert MockMdmClusterApi.remove_mdm_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_add_standby_mdm(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "standby_node",
+            "standby_mdm": {
+                "mdm_ips": [self.add_mdm_ip],
+                "role": "Manager",
+                "port": 9011,
+                "management_ips": [self.add_mdm_ip],
+                "virtual_interfaces": ["ens1"],
+                "allow_multiple_ips": True
+            },
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.add_standby_mdm = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.add_standby_mdm.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_add_standby_mdm_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": MockMdmClusterApi.MDM_NAME,
+            "standby_mdm": {
+                "mdm_ips": ["10.x.z.z"],
+                "role": "TieBreaker",
+                "port": 9011
+            },
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_add_standby_mdm_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "standby_node",
+            "standby_mdm": {
+                "mdm_ips": [self.add_mdm_ip],
+                "role": "Manager",
+                "port": 9011,
+                "management_ips": [self.add_mdm_ip],
+                "virtual_interfaces": ["ens1"],
+                "allow_multiple_ips": True
+            },
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.add_standby_mdm = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.add_standby_mdm.assert_called()
+        assert MockMdmClusterApi.add_mdm_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_change_mdm_cluster_owner(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "sample_mdm1",
+            "is_primary": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.change_mdm_ownership = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.change_mdm_ownership.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_change_mdm_cluster_owner_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": "5908d328581d1400",
+            "is_primary": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(
+            MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_change_mdm_cluster_owner_execption(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "sample_mdm1",
+            "is_primary": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.change_mdm_ownership = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.change_mdm_ownership.assert_called()
+        assert MockMdmClusterApi.owner_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_expand_mdm_cluster_mode(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "cluster_mode": "FiveNodes",
+            "mdm": [
+                {
+                    "mdm_name": MockMdmClusterApi.MDM_NAME_STB_MGR,
+                    "mdm_id": None,
+                    "mdm_type": "Secondary"
+                },
+                {
+                    "mdm_id": MockMdmClusterApi.STB_TB_MDM_ID,
+                    "mdm_name": None,
+                    "mdm_type": "TieBreaker"
+                }
+            ],
+            "mdm_state": "present-in-cluster",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_reduce_mdm_cluster_mode_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "cluster_mode": "ThreeNodes",
+            "mdm": [
+                {
+                    "mdm_name": None,
+                    "mdm_id": MockMdmClusterApi.STB_MGR_MDM_ID,
+                    "mdm_type": "Secondary"
+                },
+                {
+                    "mdm_id": None,
+                    "mdm_name": MockMdmClusterApi.MDM_NAME,
+                    "mdm_type": "TieBreaker"
+                }
+            ],
+            "mdm_state": "absent-in-cluster",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_expand_mdm_cluster_mode_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "cluster_mode": "FiveNodes",
+            "mdm": [
+                {
+                    "mdm_name": MockMdmClusterApi.MDM_NAME_STB_MGR,
+                    "mdm_id": None,
+                    "mdm_type": "Secondary"
+                },
+                {
+                    "mdm_id": MockMdmClusterApi.STB_TB_MDM_ID,
+                    "mdm_name": None,
+                    "mdm_type": "TieBreaker"
+                }
+            ],
+            "mdm_state": "present-in-cluster",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode.assert_called()
+        assert MockMdmClusterApi.switch_mode_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_reduce_mdm_cluster_mode(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "cluster_mode": "ThreeNodes",
+            "mdm": [
+                {
+                    "mdm_name": None,
+                    "mdm_id": MockMdmClusterApi.STB_MGR_MDM_ID,
+                    "mdm_type": "Secondary"
+                },
+                {
+                    "mdm_id": None,
+                    "mdm_name": MockMdmClusterApi.MDM_NAME,
+                    "mdm_type": "TieBreaker"
+                }
+            ],
+            "mdm_state": "absent-in-cluster",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.FIVE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.switch_cluster_mode.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_clear_virtual_ip_interface_mdm(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": MockMdmClusterApi.STB_MGR_MDM_ID,
+            "clear_interfaces": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface = MagicMock()
+        mdm_cluster_module_mock.perform_module_operation()
+        mdm_cluster_module_mock.powerflex_conn.system.modify_virtual_ip_interface.assert_called()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_clear_virtual_ip_interface_mdm_idempotency(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "sample_mdm11",
+            "clear_interfaces": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.FIVE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert mdm_cluster_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_get_system_id_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_module_mock.powerflex_conn.system.get = MagicMock(
+            side_effect=utils.PowerFlexClient
+        )
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.system_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_remove_mdm_cluster_owner_none(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "absent"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.remove_mdm_no_id_name_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_expand_cluster_without_standby(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "cluster_mode": "FiveNodes",
+            "mdm": [
+                {
+                    "mdm_name": None,
+                    "mdm_id": None,
+                    "mdm_type": "Secondary"
+                },
+                {
+                    "mdm_id": None,
+                    "mdm_name": None,
+                    "mdm_type": "TieBreaker"
+                }
+            ],
+            "mdm_state": "present-in-cluster",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS_2)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.without_standby_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_get_system_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        system_resp = MockSDKResponse(MockMdmClusterApi.PARTIAL_SYSTEM_DETAILS_1)
+        mdm_cluster_module_mock.powerflex_conn.system.get = MagicMock(
+            return_value=system_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value={}
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.no_cluster_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_clear_virtual_ip_interface_mdm_id_none(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": None,
+            "clear_interfaces": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.is_mdm_name_id_exists = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS['master']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.id_none_interface_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_rename_mdm_id_none(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": None,
+            "mdm_new_name": "new_node",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.is_mdm_name_id_exists = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS['master']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.id_none_rename_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_change_owner_id_none(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_id": None,
+            "is_primary": True,
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.is_mdm_name_id_exists = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS['master']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.id_none_change_owner_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_get_multiple_system_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        system_resp = MockSDKResponse(MockMdmClusterApi.PARTIAL_SYSTEM_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get = MagicMock(
+            return_value=system_resp.__dict__['data']
+        )
+        mdm_cluster_resp = MockSDKResponse(MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS)
+        mdm_cluster_module_mock.powerflex_conn.system.get_mdm_cluster_details = MagicMock(
+            return_value=mdm_cluster_resp.__dict__['data']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.multiple_system_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_add_standby_mdm_new_name_exception(self, mdm_cluster_module_mock):
+        self.get_module_args.update({
+            "mdm_name": "standby_node",
+            "standby_mdm": {
+                "mdm_ips": [self.add_mdm_ip],
+                "role": "Manager",
+                "port": 9011,
+                "management_ips": [self.add_mdm_ip],
+                "virtual_interfaces": ["ens1"],
+                "allow_multiple_ips": True
+            },
+            "mdm_new_name": "new_node",
+            "state": "present"
+        })
+        mdm_cluster_module_mock.module.params = self.get_module_args
+        mdm_cluster_module_mock.get_mdm_cluster_details = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS
+        )
+        mdm_cluster_module_mock.is_mdm_name_id_exists = MagicMock(
+            return_value=MockMdmClusterApi.THREE_MDM_CLUSTER_DETAILS['master']
+        )
+        mdm_cluster_module_mock.perform_module_operation()
+        assert MockMdmClusterApi.new_name_add_mdm_failed_response() in mdm_cluster_module_mock.module.fail_json.call_args[1]['msg']

--- a/tests/unit/plugins/modules/test_protection_domain.py
+++ b/tests/unit/plugins/modules/test_protection_domain.py
@@ -1,17 +1,12 @@
-# Copyright: (c) 2022, DellEMC
+# Copyright: (c) 2022, Dell Technologies
 
 # Apache License version 2.0 (see MODULE-LICENSE or http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-"""Unit Tests for Protection Domain module on PowerFlex"""
+"""Unit Tests for Protection Domain module on Dell Technologies (Dell) PowerFlex"""
 
 from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'
-                    }
-
 import pytest
 from mock.mock import MagicMock
 from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_protection_domain_api import MockProtectionDomainApi
@@ -20,7 +15,7 @@ from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_
 from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_api_exception \
     import MockApiException
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
-    import dellemc_ansible_powerflex_utils as utils
+    import utils
 
 utils.get_logger = MagicMock()
 utils.get_powerflex_gateway_host_connection = MagicMock()


### PR DESCRIPTION
# Description
Ansible modules for PowerFlex release version 1.3.0 include:
- Add/remove standby MDM, rename MDM, change MDM cluster ownership, switch MDM cluster mode, set performance profile, modify virtual IP interfaces and Get high-level details of MDM cluster.
- Added execution environment manifest file to support building an execution environment with ansible-builder.
- Enabled the check_mode support for the info module


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [X] I have performed Ansible Sanity test using --docker default
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Functional testing
- [X] Regression testing
- [X] Unit testing
