### PR TITLE
Ansible modules for PowerFlex version 2.3.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 # Trisha Datta (trisha-dell)
 
 # for all files:
-* @kuttattz @Bhavneet-Sharma @Jennifer-John @meenakshidembi691 @Pavan-Mudunuri @trisha-dell
+* @kuttattz @Bhavneet-Sharma @Jennifer-John @meenakshidembi691 @Pavan-Mudunuri @trisha-dell @felixs88 @sachin-apa

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,8 @@ v2.3.0
 Minor Changes
 -------------
 
-- Add support for PowerFlex ansible modules and roles on Azure.
-- Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+- Added support for PowerFlex ansible modules and roles on Azure.
+- Added support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
 - The Info module is enhanced to list out all the firmware repository.
 
 New Modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Minor Changes
 
 - Added support for PowerFlex ansible modules and roles on Azure.
 - Added support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
-- The Info module is enhanced to list out all the firmware repository.
+- The Info module is enhanced to list the firmware repositories.
 
 New Modules
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ Dellemc.PowerFlex Change Logs
 .. contents:: Topics
 
 
+v2.3.0
+======
+
+Minor Changes
+-------------
+
+- Add support for PowerFlex ansible modules and roles on Azure.
+- Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+- The Info module is enhanced to list out all the firmware repository.
+
+New Modules
+-----------
+
+- dellemc.powerflex.resource_group - Manage resource group deployments on Dell PowerFlex
+
 v2.2.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -6,29 +6,29 @@ The capabilities of the Ansible modules are managing SDCs, volumes, snapshots, s
 
 ## Table of contents
 
-* [Code of conduct](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/CODE_OF_CONDUCT.md)
-* [Maintainer guide](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/MAINTAINER_GUIDE.md)
-* [Committer guide](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/COMMITTER_GUIDE.md)
-* [Contributing guide](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/CONTRIBUTING.md)
-* [Branching strategy](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/BRANCHING.md)
-* [List of adopters](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/ADOPTERS.md)
-* [Maintainers](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/MAINTAINERS.md)
-* [Support](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/SUPPORT.md)
+* [Code of conduct](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/CODE_OF_CONDUCT.md)
+* [Maintainer guide](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/MAINTAINER_GUIDE.md)
+* [Committer guide](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/COMMITTER_GUIDE.md)
+* [Contributing guide](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/CONTRIBUTING.md)
+* [Branching strategy](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/BRANCHING.md)
+* [List of adopters](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/ADOPTERS.md)
+* [Maintainers](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/MAINTAINERS.md)
+* [Support](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/SUPPORT.md)
 * [License](#license)
-* [Security](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/SECURITY.md)
+* [Security](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/SECURITY.md)
 * [Prerequisites](#prerequisites)
 * [List of Ansible modules for Dell PowerFlex](#list-of-ansible-modules-for-dell-powerflex)
 * [Installation and execution of Ansible modules for Dell PowerFlex](#installation-and-execution-of-ansible-modules-for-dell-powerflex)
 * [Releasing, Maintenance and Deprecation](#releasing-maintenance-and-deprecation)
 
 ## License
-The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerflex/blob/2.2.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerFlex are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerflex/blob/2.2.0/MODULE-LICENSE) for the full terms.
+The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerflex/blob/2.3.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerFlex are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerflex/blob/2.3.0/MODULE-LICENSE) for the full terms.
 
 ## Prerequisites
 
 | **Ansible Modules** | **PowerFlex/VxFlex OS Version** | **SDK version** | **Python version** | **Ansible**              |
 |---------------------|-----------------------|-------|--------------------|--------------------------|
-| v2.2.0 |3.6 <br> 4.0 <br> 4.5 | 1.9.0 | 3.9.x <br> 3.10.x <br> 3.11.x | 2.14 <br> 2.15 <br> 2.16 |
+| v2.3.0 |3.6 <br> 4.0 <br> 4.5 | 2.0.0 | 3.9.x <br> 3.10.x <br> 3.11.x | 2.14 <br> 2.15 <br> 2.16 |
 
   * Please follow PyPowerFlex installation instructions on [PyPowerFlex Documentation](https://github.com/dell/python-powerflex)
   
@@ -36,22 +36,22 @@ The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 
 The modules are written in such a way that all requests are idempotent and hence fault-tolerant. It essentially means that the result of a successfully performed request is independent of the number of times it is executed.
 
 ## List of Ansible modules for Dell PowerFlex
-  * [Info module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/info.rst)
-  * [Snapshot module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/snapshot.rst)
-  * [SDC module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/sdc.rst)
-  * [Storage pool module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/storagepool.rst)
-  * [Volume module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/volume.rst)
-  * [SDS module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/sds.rst)
-  * [Device Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/device.rst)
-  * [Protection Domain Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/protection_domain.rst)
-  * [MDM Cluster Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/mdm_cluster.rst)
-  * [Replication Consistency Group Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/replication_consistency_group.rst)
-  * [Replication Pair Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/replication_pair.rst)
-  * [Snapshot Policy Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/snapshot_policy.rst)
-  * [Fault Sets Module](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/modules/fault_set.rst)
+  * [Info module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/info.rst)
+  * [Snapshot module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/snapshot.rst)
+  * [SDC module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/sdc.rst)
+  * [Storage pool module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/storagepool.rst)
+  * [Volume module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/volume.rst)
+  * [SDS module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/sds.rst)
+  * [Device Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/device.rst)
+  * [Protection Domain Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/protection_domain.rst)
+  * [MDM Cluster Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/mdm_cluster.rst)
+  * [Replication Consistency Group Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/replication_consistency_group.rst)
+  * [Replication Pair Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/replication_pair.rst)
+  * [Snapshot Policy Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/snapshot_policy.rst)
+  * [Fault Sets Module](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/modules/fault_set.rst)
 
 ## Installation and execution of Ansible modules for Dell PowerFlex
-The installation and execution steps of Ansible modules for Dell PowerFlex can be found [here](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/INSTALLATION.md).
+The installation and execution steps of Ansible modules for Dell PowerFlex can be found [here](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/INSTALLATION.md).
 
 ## Releasing, Maintenance and Deprecation
 
@@ -59,6 +59,6 @@ Ansible Modules for Dell Technologies PowerFlex follows [Semantic Versioning](ht
 
 New version will be release regularly if significant changes (bug fix or new feature) are made in the collection.
 
-Released code versions are located on "release" branches with names of the form "release-x.y.z" where x.y.z corresponds to the version number. More information on branching strategy followed can be found [here](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/BRANCHING.md).
+Released code versions are located on "release" branches with names of the form "release-x.y.z" where x.y.z corresponds to the version number. More information on branching strategy followed can be found [here](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/BRANCHING.md).
 
 Ansible Modules for Dell Technologies PowerFlex deprecation cycle is aligned with that of [Ansible](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The Ansible collection for PowerFlex is released and licensed under the GPL-3.0 
 
 | **Ansible Modules** | **PowerFlex/VxFlex OS Version** | **SDK version** | **Python version** | **Ansible**              |
 |---------------------|-----------------------|-------|--------------------|--------------------------|
-| v2.3.0 |3.6 <br> 4.0 <br> 4.5 | 2.0.0 | 3.9.x <br> 3.10.x <br> 3.11.x | 2.14 <br> 2.15 <br> 2.16 |
+| v2.3.0 |3.6 <br> 4.0 <br> 4.5 | 1.10.0 | 3.9.x <br> 3.10.x <br> 3.11.x | 2.14 <br> 2.15 <br> 2.16 |
 
   * Please follow PyPowerFlex installation instructions on [PyPowerFlex Documentation](https://github.com/dell/python-powerflex)
   

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -16,6 +16,11 @@ plugins:
       name: device
       namespace: ''
       version_added: 1.1.0
+    fault_set:
+      description: Manage Fault Sets on Dell PowerFlex
+      name: fault_set
+      namespace: ''
+      version_added: 2.2.0
     info:
       description: Gathering information about Dell PowerFlex
       name: info
@@ -41,6 +46,11 @@ plugins:
       name: replication_pair
       namespace: ''
       version_added: 1.6.0
+    resource_group:
+      description: Manage resource group deployments on Dell PowerFlex.
+      name: resource_group
+      namespace: ''
+      version_added: 2.3.0
     sdc:
       description: Manage SDCs on Dell PowerFlex
       name: sdc
@@ -76,4 +86,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 2.1.0
+version: 2.3.0

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -151,7 +151,7 @@ releases:
       minor_changes:
         - Added support for resource group provisioning to validate, deploy,
           edit, add nodes and delete a resource group.
-        - The Info module is enhanced to list out all the firmware repository.
+        - The Info module is enhanced to list the firmware repositories.
         - Added support for PowerFlex ansible modules and roles on Azure.
     modules:
       - description: Manage resource group deployments on Dell PowerFlex

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -149,9 +149,9 @@ releases:
   2.3.0:
     changes:
       minor_changes:
-        - Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+        - Added support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
         - The Info module is enhanced to list out all the firmware repository.
-        - Add support for PowerFlex ansible modules and roles on Azure.
+        - Added support for PowerFlex ansible modules and roles on Azure.
     modules:
       - description: Manage resource group deployments on Dell PowerFlex
         name: resource_group

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -146,3 +146,14 @@ releases:
         name: fault_set
         namespace: ''
     release_date: '2024-02-29'
+  2.3.0:
+    changes:
+      minor_changes:
+        - Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+        - The Info module is enhanced to list out all the firmware repository.
+        - Add support for PowerFlex ansible modules and roles on Azure.
+    modules:
+      - description: Manage resource group deployments on Dell PowerFlex
+        name: resource_group
+        namespace: ''
+    release_date: '2024-03-29'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -149,7 +149,8 @@ releases:
   2.3.0:
     changes:
       minor_changes:
-        - Added support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+        - Added support for resource group provisioning to validate, deploy,
+          edit, add nodes and delete a resource group.
         - The Info module is enhanced to list out all the firmware repository.
         - Added support for PowerFlex ansible modules and roles on Azure.
     modules:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,7 +10,7 @@ You may obtain a copy of the License at
 
 # How to contribute
 
-Become one of the contributors to this project! We thrive to build a welcoming and open community for anyone who wants to use the project or contribute to it. There are just a few small guidelines you need to follow. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](https://github.com/dell/ansible-powerflex/blob/2.2.0/CODE_OF_CONDUCT.md).
+Become one of the contributors to this project! We thrive to build a welcoming and open community for anyone who wants to use the project or contribute to it. There are just a few small guidelines you need to follow. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](https://github.com/dell/ansible-powerflex/blob/2.3.0/CODE_OF_CONDUCT.md).
 
 ## Table of contents
 
@@ -76,7 +76,7 @@ Triage helps ensure that issues resolve quickly by:
 
 If you don't have the knowledge or time to code, consider helping with _issue triage_. The Ansible modules for Dell PowerFlex community will thank you for saving them time by spending some of yours.
 
-Read more about the ways you can [Triage issues](https://github.com/dell/ansible-powerflex/blob/2.2.0/ISSUE_TRIAGE.md).
+Read more about the ways you can [Triage issues](https://github.com/dell/ansible-powerflex/blob/2.3.0/ISSUE_TRIAGE.md).
 
 ## Your first contribution
 
@@ -89,7 +89,7 @@ When you're ready to contribute, it's time to create a pull request.
 
 ## Branching
 
-* [Branching Strategy for Ansible modules for Dell PowerFlex](https://github.com/dell/ansible-powerflex/blob/2.2.0/BRANCHING.md)
+* [Branching Strategy for Ansible modules for Dell PowerFlex](https://github.com/dell/ansible-powerflex/blob/2.3.0/BRANCHING.md)
 
 ## Signing your commits
 
@@ -144,7 +144,7 @@ Make sure that the title for your pull request uses the same format as the subje
 
 ### Quality gates for pull requests
 
-GitHub Actions are used to enforce quality gates when a pull request is created or when any commit is made to the pull request. These GitHub Actions enforce our minimum code quality requirement for any code that get checked into the repository. If any of the quality gates fail, it is expected that the contributor will look into the check log, understand the problem and resolve the issue. If help is needed, please feel free to reach out the maintainers of the project for [support](https://github.com/dell/ansible-powerflex/blob/2.2.0/SUPPORT.md).
+GitHub Actions are used to enforce quality gates when a pull request is created or when any commit is made to the pull request. These GitHub Actions enforce our minimum code quality requirement for any code that get checked into the repository. If any of the quality gates fail, it is expected that the contributor will look into the check log, understand the problem and resolve the issue. If help is needed, please feel free to reach out the maintainers of the project for [support](https://github.com/dell/ansible-powerflex/blob/2.3.0/SUPPORT.md).
 
 #### Code sanitization
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -41,7 +41,7 @@ You may obtain a copy of the License at
 
   * Download the latest tar build from any of the available distribution channel [Ansible Galaxy](https://galaxy.ansible.com/dellemc/powerflex) /[Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dellemc/powerflex) and use this command to install the collection anywhere in your system:
  
-        ansible-galaxy collection install dellemc-powerflex-2.2.0.tar.gz -p <install_path>
+        ansible-galaxy collection install dellemc-powerflex-2.3.0.tar.gz -p <install_path>
 
   * Set the environment variable:
   
@@ -68,7 +68,7 @@ You may obtain a copy of the License at
 
 ## Ansible modules execution
 
-The Ansible server must be configured with Python library for PowerFlex to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
+The Ansible server must be configured with Python library for PowerFlex to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
 
 ## SSL certificate validation
 

--- a/docs/ISSUE_TRIAGE.md
+++ b/docs/ISSUE_TRIAGE.md
@@ -44,7 +44,7 @@ Should explain what happened, what was expected and how to reproduce it together
  - Ansible Version: [e.g. 2.14]
  - Python Version [e.g. 3.11]
  - Ansible modules for Dell PowerFlex Version: [e.g. 2.3.0]
- - PowerFlex SDK version: [e.g. PyPowerFlex 2.0.0]
+ - PowerFlex SDK version: [e.g. PyPowerFlex 1.10.0]
  - Any other additional information...
 
 #### Feature requests

--- a/docs/ISSUE_TRIAGE.md
+++ b/docs/ISSUE_TRIAGE.md
@@ -43,8 +43,8 @@ Should explain what happened, what was expected and how to reproduce it together
 
  - Ansible Version: [e.g. 2.14]
  - Python Version [e.g. 3.11]
- - Ansible modules for Dell PowerFlex Version: [e.g. 2.2.0]
- - PowerFlex SDK version: [e.g. PyPowerFlex 1.9.0]
+ - Ansible modules for Dell PowerFlex Version: [e.g. 2.3.0]
+ - PowerFlex SDK version: [e.g. PyPowerFlex 2.0.0]
  - Any other additional information...
 
 #### Feature requests

--- a/docs/MAINTAINER_GUIDE.md
+++ b/docs/MAINTAINER_GUIDE.md
@@ -27,7 +27,7 @@ If a candidate is approved, a Maintainer contacts the candidate to invite them t
 ## Maintainer policies
 
 * Lead by example
-* Follow the [Code of Conduct](https://github.com/dell/ansible-powerflex/blob/2.2.0/CODE_OF_CONDUCT.md) and the guidelines in the [Contributing](https://github.com/dell/ansible-powerflex/blob/2.2.0/CONTRIBUTING.md) and [Committer](https://github.com/dell/ansible-powerflex/blob/2.2.0/COMMITTER_GUIDE.md) guides
+* Follow the [Code of Conduct](https://github.com/dell/ansible-powerflex/blob/2.3.0/CODE_OF_CONDUCT.md) and the guidelines in the [Contributing](https://github.com/dell/ansible-powerflex/blob/2.3.0/CONTRIBUTING.md) and [Committer](https://github.com/dell/ansible-powerflex/blob/2.3.0/COMMITTER_GUIDE.md) guides
 * Promote a friendly and collaborative environment within our community
 * Be actively engaged in discussions, answering questions, updating defects, and reviewing pull requests
 * Criticize code, not people. Ideally, tell the contributor a better way to do what they need.

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -1,6 +1,6 @@
 **Ansible Modules for Dell Technologies PowerFlex** 
 =========================================
-### Release notes 2.2.0
+### Release notes 2.3.0
 
 >   © 2024 Dell Inc. or its subsidiaries. All rights reserved. Dell
 >   and other trademarks are trademarks of Dell Inc. or its
@@ -28,7 +28,7 @@ Table 1. Revision history
 
 | Revision | Date            | Description                                                 |
 |----------|-----------------|-------------------------------------------------------------|
-| 01       | February 2024   | Current release of Ansible Modules for Dell PowerFlex 2.2.0 |
+| 01       | March 2024      | Current release of Ansible Modules for Dell PowerFlex 2.3.0 |
 
 Product description
 -------------------
@@ -36,7 +36,7 @@ Product description
 The Ansible modules for Dell PowerFlex are used to automate and orchestrate
 the deployment, configuration, and management of Dell PowerFlex storage
 systems. The capabilities of Ansible modules are managing volumes,
-storage pools, SDCs, snapshots, snapshot policy, SDSs, replication consistency groups, replication pairs, devices, protection domain, MDM and fault sets. 
+storage pools, SDCs, snapshots, snapshot policy, SDSs, replication consistency groups, replication pairs, resource group, devices, protection domain, MDM and fault sets. 
 cluster, and obtaining high-level information about a PowerFlex system information.
 The modules use playbooks to list, show, create, delete, and modify
 each of the entities.
@@ -44,9 +44,9 @@ each of the entities.
 New features and enhancements
 -----------------------------
 Along with the previous release deliverables, this release supports following features - 
-- Fault set module is introduced to create, get details, rename and delete fault sets.
-- The SDS module has been enhanced to facilitate SDS creation within a fault set.
-- The Info module is enhanced to retrieve lists related to fault sets, service templates, deployments, and managed devices.
+- Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+- The Info module is enhanced to list out all the firmware repository.
+- Add support for PowerFlex ansible modules and roles on Azure.
 
 Known issues
 ------------
@@ -62,11 +62,11 @@ Limitations
 Distribution
 ------------
 The software package is available for download from the [Ansible Modules
-for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/2.2.0) page.
+for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/2.3.0) page.
 
 Documentation
 -------------
-The documentation is available on [Ansible Modules for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/2.2.0/docs)
+The documentation is available on [Ansible Modules for PowerFlex GitHub](https://github.com/dell/ansible-powerflex/tree/2.3.0/docs)
 page. It includes the following:
 
    - README

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -44,9 +44,9 @@ each of the entities.
 New features and enhancements
 -----------------------------
 Along with the previous release deliverables, this release supports following features - 
-- Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
+- Added support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
 - The Info module is enhanced to list out all the firmware repository.
-- Add support for PowerFlex ansible modules and roles on Azure.
+- Added support for PowerFlex ansible modules and roles on Azure.
 
 Known issues
 ------------

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -52,7 +52,7 @@ Known issues
 ------------
 - Setting the RF cache and performance profile of the SDS during its creation fails intermittently on PowerFlex version 3.5.
 - The creation of replication pair fails when copy_type is specified as OfflineCopy on PowerFlex version 4.0.
-- Pagination in info module with offset and limit fetches more than expected records when listing service templates or deployments.
+- Pagination in info module with offset and limit fetches more than expected records when listing service templates, deployments or firmware repository.
 - Templates are fetched using the info module in spite of setting include_templates to false when listing deployments.
 
 Limitations

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -12,7 +12,7 @@ You may obtain a copy of the License at
 
 The Ansible modules for Dell PowerFlex repository are inspected for security vulnerabilities via blackduck scans and static code analysis.
 
-In addition to this, there are various security checks that get executed against a branch when a pull request is created/updated. Please refer to [pull request](https://github.com/dell/ansible-powerflex/blob/2.2.0/docs/CONTRIBUTING.md#Pull-requests) for more information.
+In addition to this, there are various security checks that get executed against a branch when a pull request is created/updated. Please refer to [pull request](https://github.com/dell/ansible-powerflex/blob/2.3.0/docs/CONTRIBUTING.md#Pull-requests) for more information.
 
 ## Reporting a vulnerability
 

--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -24,7 +24,7 @@ The below requirements are needed on the host that executes this module.
 
 - A Dell PowerFlex storage system version 3.6 or later.
 - Ansible-core 2.14 or later.
-- PyPowerFlex 2.0.0.
+- PyPowerFlex 1.10.0.
 - Python 3.9, 3.10 or 3.11.
 
 

--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -271,7 +271,7 @@ Examples
         gather_subset:
           - firmware_repository
 
-    - name: Get the list of firmware repository with includes
+    - name: Get the list of firmware repository
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"

--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -24,7 +24,7 @@ The below requirements are needed on the host that executes this module.
 
 - A Dell PowerFlex storage system version 3.6 or later.
 - Ansible-core 2.14 or later.
-- PyPowerFlex 1.9.0.
+- PyPowerFlex 2.0.0.
 - Python 3.9, 3.10 or 3.11.
 
 

--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -283,7 +283,7 @@ Examples
         include_bundles: true
         include_components: true
 
-    - name: Get the list of firmware repository with includes
+    - name: Get the list of firmware repository with filter
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"

--- a/docs/modules/info.rst
+++ b/docs/modules/info.rst
@@ -271,7 +271,7 @@ Examples
         gather_subset:
           - firmware_repository
 
-    - name: Get the list of firmware repository with includes related, bundles, and components
+    - name: Get the list of firmware repository with includes
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"
@@ -283,7 +283,7 @@ Examples
         include_bundles: true
         include_components: true
 
-    - name: Get the list of firmware repository with filter, includes related, bundles and components
+    - name: Get the list of firmware repository with includes
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"
@@ -306,12 +306,12 @@ Examples
       ansible.builtin.debug:
         msg: "{{ result_repository_out.FirmwareRepository | selectattr('state', 'equalto', 'available') }}"
 
-    - name: Get the list of software components for the specific firmware repository
+    - name: Get the list of software components in the firmware repository
       ansible.builtin.debug:
         msg: "{{ result_repository_out.FirmwareRepository |
             selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareComponents') | flatten }}"
 
-    - name: Get the list of software bundles for the specific firmware repository
+    - name: Get the list of software bundles in the firmware repository
       ansible.builtin.debug:
         msg: "{{ result_repository_out.FirmwareRepository |
             selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareBundles') | flatten }}"

--- a/docs/modules/resource_group.rst
+++ b/docs/modules/resource_group.rst
@@ -22,7 +22,7 @@ The below requirements are needed on the host that executes this module.
 
 - A Dell PowerFlex storage system version 3.6 or later.
 - Ansible-core 2.14 or later.
-- PyPowerFlex 1.10.0.
+- PyPowerFlex 2.0.0.
 - Python 3.9, 3.10 or 3.11.
 
 
@@ -148,6 +148,7 @@ Notes
 
 .. note::
    - The *check_mode* is supported.
+   - Resource group scale up can be done only when deployment is complete.
    - The modules present in the collection named as 'dellemc.powerflex' are built to support the Dell PowerFlex storage platform.
 
 

--- a/docs/modules/resource_group.rst
+++ b/docs/modules/resource_group.rst
@@ -22,7 +22,7 @@ The below requirements are needed on the host that executes this module.
 
 - A Dell PowerFlex storage system version 3.6 or later.
 - Ansible-core 2.14 or later.
-- PyPowerFlex 2.0.0.
+- PyPowerFlex 1.10.0.
 - Python 3.9, 3.10 or 3.11.
 
 

--- a/playbooks/modules/info.yml
+++ b/playbooks/modules/info.yml
@@ -100,7 +100,7 @@
         include_bundles: true
         include_components: true
 
-    - name: Get the list of firmware repository with filter with includes
+    - name: Get the list of firmware repository with filter
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"

--- a/playbooks/modules/info.yml
+++ b/playbooks/modules/info.yml
@@ -88,7 +88,7 @@
         gather_subset:
           - firmware_repository
 
-    - name: Get the list of firmware repository with includes related, bundles, and components
+    - name: Get the list of firmware repository with includes
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"
@@ -100,7 +100,7 @@
         include_bundles: true
         include_components: true
 
-    - name: Get the list of firmware repository with filter, includes related, bundles and components
+    - name: Get the list of firmware repository with filter with includes
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"
@@ -121,14 +121,17 @@
 
     - name: Get the list of available firmware repository
       ansible.builtin.debug:
-        msg: "{{ result_repository_out.FirmwareRepository | selectattr('state', 'equalto', 'available') }}"
+        msg: "{{ result_repository_out.FirmwareRepository |
+          selectattr('state', 'equalto', 'available') }}"
 
-    - name: Get the list of software components for the specific firmware repository
+    - name: Get the list of software components in the firmware repository
       ansible.builtin.debug:
         msg: "{{ result_repository_out.FirmwareRepository |
-          selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareComponents') | flatten }}"
+          selectattr('id', 'equalto', '8aaa80788b7') |
+          map(attribute='softwareComponents') | flatten }}"
 
-    - name: Get the list of software bundles for the specific firmware repository
+    - name: Get the list of software bundles in the firmware repository
       ansible.builtin.debug:
         msg: "{{ result_repository_out.FirmwareRepository |
-          selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareBundles') | flatten }}"
+          selectattr('id', 'equalto', '8aaa80788b7') |
+          map(attribute='softwareBundles') | flatten }}"

--- a/playbooks/modules/info.yml
+++ b/playbooks/modules/info.yml
@@ -88,7 +88,7 @@
         gather_subset:
           - firmware_repository
 
-    - name: Get the list of firmware repository with includes
+    - name: Get the list of firmware repository
       dellemc.powerflex.info:
         hostname: "{{ hostname }}"
         username: "{{ username }}"

--- a/plugins/doc_fragments/powerflex.py
+++ b/plugins/doc_fragments/powerflex.py
@@ -53,7 +53,7 @@ class ModuleDocFragment(object):
     requirements:
       - A Dell PowerFlex storage system version 3.6 or later.
       - Ansible-core 2.14 or later.
-      - PyPowerFlex 2.0.0.
+      - PyPowerFlex 1.10.0.
       - Python 3.9, 3.10 or 3.11.
     notes:
       - The modules present in the collection named as 'dellemc.powerflex'

--- a/plugins/doc_fragments/powerflex.py
+++ b/plugins/doc_fragments/powerflex.py
@@ -53,7 +53,7 @@ class ModuleDocFragment(object):
     requirements:
       - A Dell PowerFlex storage system version 3.6 or later.
       - Ansible-core 2.14 or later.
-      - PyPowerFlex 1.9.0.
+      - PyPowerFlex 2.0.0.
       - Python 3.9, 3.10 or 3.11.
     notes:
       - The modules present in the collection named as 'dellemc.powerflex'

--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -83,10 +83,10 @@ def ensure_required_libs(module):
                          exception=PKG_RSRC_IMP_ERR)
 
     if not HAS_POWERFLEX_SDK:
-        module.fail_json(msg=missing_required_lib("PyPowerFlex V 1.9.0 or above"),
+        module.fail_json(msg=missing_required_lib("PyPowerFlex V 1.10.0 or above"),
                          exception=POWERFLEX_SDK_IMP_ERR)
 
-    min_ver = '1.9.0'
+    min_ver = '1.10.0'
     try:
         curr_version = pkg_resources.require("PyPowerFlex")[0].version
         supported_version = (parse_version(curr_version) >= parse_version(min_ver))

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -224,7 +224,7 @@ EXAMPLES = r'''
     gather_subset:
       - firmware_repository
 
-- name: Get the list of firmware repository with includes
+- name: Get the list of firmware repository
   dellemc.powerflex.info:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
@@ -236,7 +236,7 @@ EXAMPLES = r'''
     include_bundles: true
     include_components: true
 
-- name: Get the list of firmware repository with includes
+- name: Get the list of firmware repository with filter
   dellemc.powerflex.info:
     hostname: "{{ hostname }}"
     username: "{{ username }}"

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -224,7 +224,7 @@ EXAMPLES = r'''
     gather_subset:
       - firmware_repository
 
-- name: Get the list of firmware repository with includes related, bundles, and components
+- name: Get the list of firmware repository with includes
   dellemc.powerflex.info:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
@@ -236,7 +236,7 @@ EXAMPLES = r'''
     include_bundles: true
     include_components: true
 
-- name: Get the list of firmware repository with filter, includes related, bundles and components
+- name: Get the list of firmware repository with includes
   dellemc.powerflex.info:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
@@ -259,12 +259,12 @@ EXAMPLES = r'''
   ansible.builtin.debug:
     msg: "{{ result_repository_out.FirmwareRepository | selectattr('state', 'equalto', 'available') }}"
 
-- name: Get the list of software components for the specific firmware repository
+- name: Get the list of software components in the firmware repository
   ansible.builtin.debug:
     msg: "{{ result_repository_out.FirmwareRepository |
         selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareComponents') | flatten }}"
 
-- name: Get the list of software bundles for the specific firmware repository
+- name: Get the list of software bundles in the firmware repository
   ansible.builtin.debug:
     msg: "{{ result_repository_out.FirmwareRepository |
         selectattr('id', 'equalto', '8aaa80788b7') | map(attribute='softwareBundles') | flatten }}"

--- a/plugins/modules/resource_group.py
+++ b/plugins/modules/resource_group.py
@@ -96,6 +96,7 @@ options:
     default: 'present'
 notes:
 - The I(check_mode) is supported.
+- Resource group scale up can be done only when deployment is complete.
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
# Description
- Add support for PowerFlex ansible modules and roles on Azure.
- Add support for resource group provisioning to validate, deploy, edit, add nodes and delete a resource group.
- The Info module is enhanced to list out all the firmware repository.

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [X] I have performed Ansible Sanity test using --docker default
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Unit testing
- [X] Functional testing
- [X] Regression testing
