### PR TITLE
don't check gateway cert by default in the example

### DIFF
--- a/playbooks/roles/group_vars/all
+++ b/playbooks/roles/group_vars/all
@@ -1,6 +1,7 @@
 powerflex_common_file_install_location: "/var/tmp"
 powerflex_common_esxi_files_location: "/tmp/"
 powerflex_common_win_package_location: "C:\\Windows\\Temp"
+powerflex_gateway_disable_gpg_check: true
 # powerflex sdc params
 powerflex_sdc_driver_sync_repo_address: 'ftp://ftp.emc.com/'
 powerflex_sdc_driver_sync_repo_user: 'QNzgdxXix'


### PR DESCRIPTION
# Description
It is helpful to have that variable set by default

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Tested in the lab successfully
