### PR TITLE
Compatibility check for modules

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ name: powerflex
 
 # The version of the collection.
 # Must be compatible with semantic versioning
-version: 2.6.1
+version: 3.0.0
 
 # The path to the Markdown (.md) readme file.
 # This path is relative to the root of the collection.
@@ -32,6 +32,12 @@ authors:
   - Ananthu S Kuttattu <ansible.team@dell.com>
   - Trisha Datta <ansible.team@dell.com>
   - Pavan Mudunuri <ansible.team@dell.com>
+  - Yiming Bao <ansible.team@dell.com>
+  - Luis Liu <ansible.team@dell.com>
+  - Peter Cao <ansible.team@dell.com>
+  - Ray Liu <ansible.team@dell.com>
+  - Tao he <ansible.team@dell.com>
+  - Haiming Tan <ansible.team@dell.com>
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection

--- a/plugins/module_utils/storage/dell/libraries/powerflex_base.py
+++ b/plugins/module_utils/storage/dell/libraries/powerflex_base.py
@@ -6,8 +6,12 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 
+import inspect
+from pathlib import Path
+
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
     import utils
+
 
 LOG = utils.get_logger('powerflex_base')
 
@@ -43,3 +47,93 @@ class PowerFlexBase:
         except Exception as e:
             LOG.error(str(e))
             self.module.fail_json(msg=str(e))
+
+    def check_module_compatibility(self):
+        """
+        Check if the current module class is compatible with the target PowerFlex version.
+        """
+
+        current_class = self.__class__
+        current_file = Path(inspect.getfile(current_class)).resolve()
+        current_module = current_file.stem
+
+        if not hasattr(current_class, '_powerflex_compatibility'):
+            return
+        compatibilities = current_class._powerflex_compatibility
+        if not compatibilities:
+            return
+
+        min_ver = compatibilities.get('min_ver', None)
+        max_ver = compatibilities.get('max_ver', None)
+        successor = compatibilities.get('successor', None)
+        predecessor = compatibilities.get('predecessor', None)
+
+        api_version = self.powerflex_conn.system.api_version(cached=True)
+        if (pfmp_version := self.get_pfmp_version()) is None:
+            pfmp_version = api_version
+
+        if min_ver and utils.is_version_less(api_version, min_ver):
+            if predecessor:
+                self.__skip_module(warnings=[
+                    f"Please use module {predecessor} for PowerFlex {pfmp_version}"
+                ])
+            self.__skip_module(warnings=[
+                f"Module {current_module} is not compatible with PowerFlex {pfmp_version}. "
+                f"The minimum supported version of module {current_module} is {min_ver}."
+            ])
+
+        if max_ver and utils.is_version_ge_or_eq(api_version, max_ver):
+            if successor:
+                self.__skip_module(warnings=[
+                    f"Please use module {successor} for PowerFlex {pfmp_version}"
+                ])
+            self.__skip_module(warnings=[
+                f"Module {current_module} is not compatible with PowerFlex {pfmp_version}. "
+                f"The maximum supported version of module {current_module} is below {max_ver}."
+            ])
+
+    def __skip_module(self, warnings):
+        """
+        Skip the module execution with a message.
+
+        :param msg: Message to display when skipping the module
+        :type msg: str
+        """
+        self.module.exit_json(
+            changed=False,
+            msg='Task Skipped!',
+            warnings=warnings
+        )
+
+    def get_pfmp_version(self):
+        """
+        Get the PowerFlex Management Platform version.
+
+        :return: PowerFlex Management Platform version
+        :rtype: str
+        """
+        try:
+            return self.powerflex_conn.system.pfmp_version(cached=True)
+        except Exception:
+            return None
+
+
+def powerflex_compatibility(min_ver, max_ver=None, predecessor=None, successor=None):
+    """
+    Decorator to mark a module class as compatible from a specific PowerFlex version.
+
+    Args:
+        min_ver (str): Minimum PowerFlex version (inclusive) this module supports.
+        max_ver (str): Optional Maximum PowerFlex version (exclusive) this module supports.
+        predecessor (str): Optional predecessor module if PowerFlex version is lower than min_ver.
+        successor (str): Optional successor module if PowerFlex version is higher than max_ver.
+    """
+    def decorator(cls):
+        cls._powerflex_compatibility = {
+            'min_ver': min_ver,
+            'max_ver': max_ver,
+            'predecessor': predecessor,
+            'successor': successor
+        }
+        return cls
+    return decorator

--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -20,7 +20,7 @@ import string
 """import PyPowerFlex lib"""
 try:
     from PyPowerFlex import PowerFlexClient
-    from PyPowerFlex.objects.system import SnapshotDef  # pylint: disable=unused-import
+    from PyPowerFlex.objects.common.system import SnapshotDef  # pylint: disable=unused-import
     from PyPowerFlex.utils import filter_response  # pylint: disable=unused-import
     HAS_POWERFLEX_SDK, POWERFLEX_SDK_IMP_ERR = True, None
 except ImportError:
@@ -157,18 +157,24 @@ def get_size_in_gb(size, cap_units):
     return size_in_gb
 
 
-def is_version_less_than_3_6(version):
-    """Verifies if powerflex version is less than 3.6"""
-    version = re.search(r'R\s*([\d.]+)', version.replace('_', '.')).group(1)
-    return \
-        LooseVersion(version) < LooseVersion('3.6')
+def parse_version(version):
+    """Parse PowerFlex version e.g. R4_5.4000.0 to 4.5.4000.0."""
+    return re.search(r'R\s*([\d.]+)', version.replace('_', '.')).group(1)
 
 
-def is_version_less_than_4_6(version):
-    """Verifies if powerflex version is less than 3.6"""
-    version = re.search(r'R\s*([\d.]+)', version.replace('_', '.')).group(1)
-    return \
-        LooseVersion(version) < LooseVersion('4.6')
+def is_version_ge(version, target="5.0"):
+    """Check if the PowerFlex version is greater than the target version."""
+    return LooseVersion(version) > LooseVersion(target)
+
+
+def is_version_less(version, target="5.0"):
+    """Check if the PowerFlex version is less than the target version."""
+    return LooseVersion(version) < LooseVersion(target)
+
+
+def is_version_ge_or_eq(version, target="5.0"):
+    """Check if the PowerFlex version is greater than or equal to the target version."""
+    return LooseVersion(version) >= LooseVersion(target)
 
 
 def is_invalid_name(name):

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -2449,7 +2449,8 @@ class PowerFlexInfo(object):
             if rcgs:
                 api_version = self.powerflex_conn.system.get()[0]['mdmCluster']['master']['versionInfo']
                 statistics_map = \
-                    self.powerflex_conn.replication_consistency_group.get_all_statistics(utils.is_version_less_than_3_6(api_version))
+                    self.powerflex_conn.replication_consistency_group.get_all_statistics(
+                        utils.is_version_less(utils.parse_version(api_version), '3.6'))
                 list_of_rcg_ids_in_statistics = statistics_map.keys()
                 for rcg in rcgs:
                     rcg.pop('links', None)

--- a/plugins/modules/nvme_host.py
+++ b/plugins/modules/nvme_host.py
@@ -491,7 +491,7 @@ class PowerFlexNVMeHost(PowerFlexBase):
             bool: True if the API version is less than version 4.6, False otherwise.
         """
         api_version = self.powerflex_conn.system.get()[0]['mdmCluster']['master']['versionInfo']
-        version_check = utils.is_version_less_than_4_6(api_version)
+        version_check = utils.is_version_less(utils.parse_version(api_version), '4.6')
         return version_check
 
 

--- a/plugins/modules/protection_domain_v2.py
+++ b/plugins/modules/protection_domain_v2.py
@@ -1,0 +1,739 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021-25, Dell Technologies
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing protection domain on Dell Technologies (Dell) PowerFlex 5.x"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: protection_domain_v2
+version_added: '3.0.0'
+short_description: Managing protection domain on Dell PowerFlex 5.x
+
+description:
+- Dell PowerFlex protection domain module includes getting the details of
+  protection domain, creating a new protection domain, and modifying the attribute of
+  a protection domain.
+
+extends_documentation_fragment:
+  - dellemc.powerflex.powerflex
+
+author:
+- Luis Liu (@vangork) <ansible.team@dell.com>
+
+options:
+  protection_domain_name:
+    description:
+    - The name of the protection domain.
+    - Mandatory for create operation.
+    - It is unique across the PowerFlex array.
+    - Mutually exclusive with I(protection_domain_id).
+    type: str
+  protection_domain_id:
+    description:
+    - The ID of the protection domain.
+    - Except for create operation, all other operations can be performed
+      using protection_domain_id.
+    - Mutually exclusive with I(protection_domain_name).
+    type: str
+  protection_domain_new_name:
+    description:
+    - Used to rename the protection domain.
+    type: str
+  is_active:
+    description:
+      - Used to activate or deactivate the protection domain.
+    required: false
+    type: bool
+  rebuild_enabled:
+    description:
+      - Used to enable or disable rebuild.
+    required: false
+    type: bool
+  rebalance_enabled:
+    description:
+      - Used to enable or disable rebalance.
+    required: false
+    type: bool
+  io_policy:
+    description:
+      - The I/O policy of the protection domain.
+    required: false
+    type: dict
+    suboptions:
+      overall_concurrent_io_limit:
+        description:
+          - The overall concurrent I/O limit.
+        required: false
+        type: int
+      bandwidth_limit_overall_ios:
+        description:
+          - The bandwidth limit for overall I/O.
+        required: false
+        type: int
+      bandwidth_limit_bg_dev_scanner:
+        description:
+          - The bandwidth limit for background device scanner.
+        required: false
+        type: int
+      bandwidth_limit_garbage_collector:
+        description:
+          - The bandwidth limit for garbage collector.
+        required: false
+        type: int
+      bandwidth_limit_singly_impacted_rebuild:
+        description:
+          - The bandwidth limit for singly impacted rebuild.
+        required: false
+        type: int
+      bandwidth_limit_doubly_impacted_rebuild:
+        description:
+          - The bandwidth limit for doubly impacted rebuild.
+        required: false
+        type: int
+      bandwidth_limit_rebalance:
+        description:
+          - The bandwidth limit for rebalance.
+        required: false
+        type: int
+      bandwidth_limit_other:
+        description:
+          - The bandwidth limit for other operations.
+        required: false
+        type: int
+      bandwidth_limit_node_network:
+        description:
+          - The bandwidth limit for node network.
+        required: false
+        type: int
+  state:
+    description:
+      - The state of the protection domain. Can be 'present' or 'absent'.
+    required: true
+    choices: ['present', 'absent']
+    type: str
+notes:
+  - This module is supported on Dell PowerFlex 5.x and later versions.
+  - The protection domain can only be deleted if all its related objects have
+    been dissociated from the protection domain.
+  - If the protection domain set to inactive, then no operation can be
+    performed on protection domain.
+  - The I(check_mode) is not supported.
+'''
+
+EXAMPLES = r'''
+- name: Create protection domain
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    protection_domain_name: "domain1"
+    state: "present"
+
+- name: Create protection domain with all parameters
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    protection_domain_name: "domain1"
+    is_active: true
+    rebuild_enabled: true
+    rebalance_enabled: true
+    io_policy:
+      overall_concurrent_io_limit: 1000
+      bandwidth_limit_overall_ios: 100
+      bandwidth_limit_bg_dev_scanner: 50
+      bandwidth_limit_garbage_collector: 20
+      bandwidth_limit_singly_impacted_rebuild: 30
+      bandwidth_limit_doubly_impacted_rebuild: 40
+      bandwidth_limit_rebalance: 50
+      bandwidth_limit_other: 60
+      bandwidth_limit_node_network: 70
+    state: present
+
+- name: Get protection domain details using name
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    port: "{{port}}"
+    protection_domain_name: "domain1"
+    state: "present"
+
+- name: Get protection domain details using ID
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    port: "{{port}}"
+    protection_domain_id: "5718253c00000004"
+    state: "present"
+
+- name: Modify protection domain attributes
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    port: "{{port}}"
+    protection_domain_name: "domain1"
+    protection_domain_new_name: "domain1_new"
+    rebuild_enabled: false
+    rebalance_enabled: false
+    io_policy:
+      overall_concurrent_io_limit: 500
+      bandwidth_limit_overall_ios: 50
+      bandwidth_limit_bg_dev_scanner: 20
+      bandwidth_limit_garbage_collector: 10
+      bandwidth_limit_singly_impacted_rebuild: 20
+      bandwidth_limit_doubly_impacted_rebuild: 30
+      bandwidth_limit_rebalance: 40
+      bandwidth_limit_other: 50
+      bandwidth_limit_node_network: 60
+    state: "present"
+
+- name: Delete protection domain using name
+  dellemc.powerflex.protection_domain_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    port: "{{port}}"
+    protection_domain_name: "domain1_new"
+    state: "absent"
+'''
+
+RETURN = r'''
+changed:
+    description: Whether or not the resource has changed.
+    returned: always
+    type: bool
+    sample: 'false'
+protection_domain_details:
+    description: Details of the protection domain.
+    returned: When protection domain exists
+    type: dict
+    contains:
+        fglDefaultMetadataCacheSize:
+            description: FGL metadata cache size.
+            type: int
+        fglDefaultNumConcurrentWrites:
+            description: FGL concurrent writes.
+            type: str
+        fglMetadataCacheEnabled:
+            description: Whether FGL cache enabled.
+            type: bool
+        id:
+            description: Protection domain ID.
+            type: str
+        links:
+            description: Protection domain links.
+            type: list
+            contains:
+                href:
+                    description: Protection domain instance URL.
+                    type: str
+                rel:
+                    description: Protection domain's relationship with
+                                 different entities.
+                    type: str
+        mdmSdsNetworkDisconnectionsCounterParameters:
+            description: MDM's SDS counter parameter.
+            type: dict
+            contains:
+                longWindow:
+                    description: Long window for Counter Parameters.
+                    type: int
+                mediumWindow:
+                    description: Medium window for Counter Parameters.
+                    type: int
+                shortWindow:
+                    description: Short window for Counter Parameters.
+                    type: int
+        name:
+            description: Name of the protection domain.
+            type: str
+        overallIoNetworkThrottlingEnabled:
+            description: Whether overall network throttling enabled.
+            type: bool
+        overallIoNetworkThrottlingInKbps:
+            description: Overall network throttling in KBps.
+            type: int
+        protectedMaintenanceModeNetworkThrottlingEnabled:
+            description: Whether protected maintenance mode network throttling
+                         enabled.
+            type: bool
+        protectedMaintenanceModeNetworkThrottlingInKbps:
+            description: Protected maintenance mode network throttling in
+                         KBps.
+            type: int
+        protectionDomainState:
+            description: State of protection domain.
+            type: int
+        rebalanceNetworkThrottlingEnabled:
+            description: Whether rebalance network throttling enabled.
+            type: int
+        rebalanceNetworkThrottlingInKbps:
+            description: Rebalance network throttling in KBps.
+            type: int
+        rebuildNetworkThrottlingEnabled:
+            description: Whether rebuild network throttling enabled.
+            type: int
+        rebuildNetworkThrottlingInKbps:
+            description: Rebuild network throttling in KBps.
+            type: int
+        rfcacheAccpId:
+            description: Id of RF cache acceleration pool.
+            type: str
+        rfcacheEnabled:
+            description: Whether RF cache is enabled or not.
+            type: bool
+        rfcacheMaxIoSizeKb:
+            description: RF cache maximum I/O size in KB.
+            type: int
+        rfcacheOpertionalMode:
+            description: RF cache operational mode.
+            type: str
+        rfcachePageSizeKb:
+            description: RF cache page size in KB.
+            type: bool
+        sdrSdsConnectivityInfo:
+            description: Connectivity info of SDR and SDS.
+            type: dict
+            contains:
+                clientServerConnStatus:
+                    description: Connectivity status of client and server.
+                    type: str
+                disconnectedClientId:
+                    description: Disconnected client ID.
+                    type: str
+                disconnectedClientName:
+                    description: Disconnected client name.
+                    type: str
+                disconnectedServerId:
+                    description: Disconnected server ID.
+                    type: str
+                disconnectedServerIp:
+                    description: Disconnected server IP.
+                    type: str
+                disconnectedServerName:
+                    description: Disconnected server name.
+                    type: str
+        sdsSdsNetworkDisconnectionsCounterParameters:
+            description: Counter parameter for SDS-SDS network.
+            type: dict
+            contains:
+                longWindow:
+                    description: Long window for Counter Parameters.
+                    type: int
+                mediumWindow:
+                    description: Medium window for Counter Parameters.
+                    type: int
+                shortWindow:
+                    description: Short window for Counter Parameters.
+                    type: int
+        storagePool:
+            description: List of storage pools.
+            type: list
+        systemId:
+            description: ID of system.
+            type: str
+        vtreeMigrationNetworkThrottlingEnabled:
+            description: Whether V-Tree migration network throttling enabled.
+            type: bool
+        vtreeMigrationNetworkThrottlingInKbps:
+            description: V-Tree migration network throttling in KBps.
+            type: int
+    sample: {
+        "fglDefaultMetadataCacheSize": 0,
+        "fglDefaultNumConcurrentWrites": 1000,
+        "fglMetadataCacheEnabled": false,
+        "id": "7bd6457000000000",
+        "links": [
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000",
+                "rel": "self"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/Statistics",
+                "rel": "/api/ProtectionDomain/relationship/Statistics"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/Sdr",
+                "rel": "/api/ProtectionDomain/relationship/Sdr"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/AccelerationPool",
+                "rel": "/api/ProtectionDomain/relationship/AccelerationPool"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/StoragePool",
+                "rel": "/api/ProtectionDomain/relationship/StoragePool"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/Sds",
+                "rel": "/api/ProtectionDomain/relationship/Sds"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/ReplicationConsistencyGroup",
+                "rel": "/api/ProtectionDomain/relationship/
+                        ReplicationConsistencyGroup"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::7bd6457000000000/
+                        relationships/FaultSet",
+                "rel": "/api/ProtectionDomain/relationship/FaultSet"
+            },
+            {
+                "href": "/api/instances/System::0989ce79058f150f",
+                "rel": "/api/parent/relationship/systemId"
+            }
+        ],
+        "mdmSdsNetworkDisconnectionsCounterParameters": {
+            "longWindow": {
+                "threshold": 700,
+                "windowSizeInSec": 86400
+            },
+            "mediumWindow": {
+                "threshold": 500,
+                "windowSizeInSec": 3600
+            },
+            "shortWindow": {
+                "threshold": 300,
+                "windowSizeInSec": 60
+            }
+        },
+        "name": "domain1",
+        "overallIoNetworkThrottlingEnabled": false,
+        "overallIoNetworkThrottlingInKbps": null,
+        "protectedMaintenanceModeNetworkThrottlingEnabled": false,
+        "protectedMaintenanceModeNetworkThrottlingInKbps": null,
+        "protectionDomainState": "Active",
+        "rebalanceNetworkThrottlingEnabled": false,
+        "rebalanceNetworkThrottlingInKbps": null,
+        "rebuildNetworkThrottlingEnabled": false,
+        "rebuildNetworkThrottlingInKbps": null,
+        "rfcacheAccpId": null,
+        "rfcacheEnabled": true,
+        "rfcacheMaxIoSizeKb": 128,
+        "rfcacheOpertionalMode": "WriteMiss",
+        "rfcachePageSizeKb": 64,
+        "sdrSdsConnectivityInfo": {
+            "clientServerConnStatus": "CLIENT_SERVER_CONN_STATUS_ALL
+                                      _CONNECTED",
+            "disconnectedClientId": null,
+            "disconnectedClientName": null,
+            "disconnectedServerId": null,
+            "disconnectedServerIp": null,
+            "disconnectedServerName": null
+        },
+        "sdsConfigurationFailureCounterParameters": {
+            "longWindow": {
+                "threshold": 700,
+                "windowSizeInSec": 86400
+            },
+            "mediumWindow": {
+                "threshold": 500,
+                "windowSizeInSec": 3600
+            },
+            "shortWindow": {
+                "threshold": 300,
+                "windowSizeInSec": 60
+            }
+        },
+        "sdsDecoupledCounterParameters": {
+            "longWindow": {
+                "threshold": 700,
+                "windowSizeInSec": 86400
+            },
+            "mediumWindow": {
+                "threshold": 500,
+                "windowSizeInSec": 3600
+            },
+            "shortWindow": {
+                "threshold": 300,
+                "windowSizeInSec": 60
+            }
+        },
+        "sdsReceiveBufferAllocationFailuresCounterParameters": {
+            "longWindow": {
+                "threshold": 2000000,
+                "windowSizeInSec": 86400
+            },
+            "mediumWindow": {
+                "threshold": 200000,
+                "windowSizeInSec": 3600
+            },
+            "shortWindow": {
+                "threshold": 20000,
+                "windowSizeInSec": 60
+            }
+        },
+        "sdsSdsNetworkDisconnectionsCounterParameters": {
+            "longWindow": {
+                "threshold": 700,
+                "windowSizeInSec": 86400
+            },
+            "mediumWindow": {
+                "threshold": 500,
+                "windowSizeInSec": 3600
+            },
+            "shortWindow": {
+                "threshold": 300,
+                "windowSizeInSec": 60
+            }
+        },
+        "storagePool": [
+            {
+                "id": "8d1cba1700000000",
+                "name": "pool1"
+            }
+        ],
+        "systemId": "0989ce79058f150f",
+        "vtreeMigrationNetworkThrottlingEnabled": false,
+        "vtreeMigrationNetworkThrottlingInKbps": null
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import PowerFlexBase
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
+    import utils
+
+
+LOG = utils.get_logger('protection_domain_v2')
+
+
+class PowerFlexProtectionDomainV2(PowerFlexBase):
+    """Class with protection domain operations"""
+
+    def __init__(self):
+        """ Define all parameters required by this module"""
+        argument_spec = dict(
+            protection_domain_name=dict(),
+            protection_domain_new_name=dict(),
+            protection_domain_id=dict(type='str'),
+            is_active=dict(type='bool'),
+            rebuild_enabled=dict(type='bool'),
+            rebalance_enabled=dict(type='bool'),
+            io_policy=dict(type='dict', options=dict(
+                overall_concurrent_io_limit=dict(type='int'),
+                bandwidth_limit_overall_ios=dict(type='int'),
+                bandwidth_limit_bg_dev_scanner=dict(type='int'),
+                bandwidth_limit_garbage_collector=dict(type='int'),
+                bandwidth_limit_singly_impacted_rebuild=dict(type='int'),
+                bandwidth_limit_doubly_impacted_rebuild=dict(type='int'),
+                bandwidth_limit_rebalance=dict(type='int'),
+                bandwidth_limit_other=dict(type='int'),
+                bandwidth_limit_node_network=dict(type='int'),
+            )),
+            state=dict(required=True, type='str',
+                       choices=['present', 'absent'])
+        )
+
+        mut_ex_args = [['protection_domain_name', 'protection_domain_id']]
+
+        required_one_of_args = [['protection_domain_name',
+                                 'protection_domain_id']]
+
+        module_params = {
+            'argument_spec': argument_spec,
+            'supports_check_mode': False,
+            'mutually_exclusive': mut_ex_args,
+            'required_one_of': required_one_of_args,
+        }
+
+        super().__init__(AnsibleModule, module_params)
+        super().check_module_compatibility()
+
+    def get(self, id, name):
+        """
+        Get protection domain details
+        :param id: ID of the protection domain
+        :type id: str
+        :param name: Name of the protection domain
+        :type name: str
+        :return: Protection domain details if exists
+        :rtype: dict
+        """
+        name_or_id = id if id else name
+        try:
+            if id:
+                pd_details = self.powerflex_conn.protection_domain.get_by_id(
+                    id)
+            else:
+                pd_details = self.powerflex_conn.protection_domain.get_by_name(
+                    name)
+
+            return pd_details
+        except Exception as e:
+            error_msg = "Failed to get the protection domain '%s' with " \
+                        "error '%s'" % (name_or_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def delete(self, id):
+        """
+        Delete Protection Domain
+        :param id: ID of the protection domain
+        :type id: str
+        :rtype: None
+        """
+        try:
+            self.powerflex_conn.protection_domain.delete(id)
+            LOG.info("Protection domain deleted successfully.")
+        except Exception as e:
+            error_msg = "Delete protection domain '%s' operation failed" \
+                        " with error '%s'" % (id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def create(self, protection_domain):
+        """
+        Create protection domain
+        :param protection_domain: Dict of the protection domain
+        :type protection_domain: dict
+        :return: Dict representation of the created protection domain
+        """
+        try:
+            LOG.info("Creating protection domain with name: %s ",
+                     protection_domain['name'])
+            return self.powerflex_conn.protection_domain.create(protection_domain)
+        except Exception as e:
+            error_msg = "Create protection domain '%s' operation failed" \
+                        " with error '%s'" % (
+                            protection_domain['name'], str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def update(self, protection_domain, current_protection_domain=None):
+        """
+        Modify protection domain attributes
+        :param protection_domain: Dictionary containing the attributes of
+                            protection domain which are to be updated
+        :type protection_domain: dict
+        :return: Bool to indicate if protection domain is updated,
+                 Dict representation of the updated protection domain
+        """
+        try:
+            LOG.info("Updating protection domain with id: %s ",
+                     protection_domain['id'])
+            return self.powerflex_conn.protection_domain.update(protection_domain, current_protection_domain)
+        except Exception as e:
+            err_msg = "Failed to update the protection domain {0}" \
+                " with error {1}".format(protection_domain['id'], str(e))
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+    def exec(self):
+        """
+        Perform different actions on protection domain based on parameters
+        passed in the playbook
+        """
+        protection_domain_name = self.module.params['name']
+        protection_domain_id = self.module.params['id']
+        is_active = self.module.params['is_active']
+        rebuild_enabled = self.module.params['rebuild_enabled']
+        rebalance_enabled = self.module.params['rebalance_enabled']
+        io_policy = self.module.params['io_policy']
+        overall_concurrent_io_limit = None if io_policy is None else io_policy[
+            'overall_concurrent_io_limit']
+        bandwidth_limit_overall_ios = None if io_policy is None else io_policy[
+            'bandwidth_limit_overall_ios']
+        bandwidth_limit_bg_dev_scanner = None if io_policy is None else io_policy[
+            'bandwidth_limit_bg_dev_scanner']
+        bandwidth_limit_garbage_collector = None if io_policy is None else io_policy[
+            'bandwidth_limit_garbage_collector']
+        bandwidth_limit_singly_impacted_rebuild = None if io_policy is None else io_policy[
+            'bandwidth_limit_singly_impacted_rebuild']
+        bandwidth_limit_doubly_impacted_rebuild = None if io_policy is None else io_policy[
+            'bandwidth_limit_doubly_impacted_rebuild']
+        bandwidth_limit_rebalance = None if io_policy is None else io_policy[
+            'bandwidth_limit_rebalance']
+        bandwidth_limit_other = None if io_policy is None else io_policy['bandwidth_limit_other']
+        bandwidth_limit_node_network = None if io_policy is None else io_policy[
+            'bandwidth_limit_node_network']
+        state = self.module.params['state']
+
+        result = dict(
+            changed=False,
+            protection_domain_details=None
+        )
+
+        pd_details = self.get(
+            protection_domain_id,
+            protection_domain_name,
+        )
+
+        if state == 'absent':
+            if pd_details:
+                self.delete(pd_details['id'])
+                result['changed'] = True
+            self.module.exit_json(**result)
+            return
+
+        protection_domain = {}
+        if protection_domain_name is not None:
+            protection_domain['name'] = protection_domain_name
+        if is_active is not None:
+            protection_domain['protectionDomainState'] = "Active" if is_active else "Inactive"
+        if rebuild_enabled is not None:
+            protection_domain['rebuildEnabled'] = rebuild_enabled
+        if rebalance_enabled is not None:
+            protection_domain['rebalanceEnabled'] = rebalance_enabled
+        if overall_concurrent_io_limit is not None:
+            protection_domain['overallConcurrentIoLimit'] = overall_concurrent_io_limit
+        if bandwidth_limit_overall_ios is not None:
+            protection_domain['bandwidthLimitOverallIos'] = bandwidth_limit_overall_ios
+        if bandwidth_limit_bg_dev_scanner is not None:
+            protection_domain['bandwidthLimitBgDevScanner'] = bandwidth_limit_bg_dev_scanner
+        if bandwidth_limit_garbage_collector is not None:
+            protection_domain['bandwidthLimitGarbageCollector'] = bandwidth_limit_garbage_collector
+        if bandwidth_limit_singly_impacted_rebuild is not None:
+            protection_domain['bandwidthLimitSinglyImpactedRebuild'] = bandwidth_limit_singly_impacted_rebuild
+        if bandwidth_limit_doubly_impacted_rebuild is not None:
+            protection_domain['bandwidthLimitDoublyImpactedRebuild'] = bandwidth_limit_doubly_impacted_rebuild
+        if bandwidth_limit_rebalance is not None:
+            protection_domain['bandwidthLimitRebalance'] = bandwidth_limit_rebalance
+        if bandwidth_limit_other is not None:
+            protection_domain['bandwidthLimitOther'] = bandwidth_limit_other
+        if bandwidth_limit_node_network is not None:
+            protection_domain['bandwidthLimitNodeNetwork'] = bandwidth_limit_node_network
+
+        if not pd_details:
+            result['protection_domain_details'] = self.create(
+                protection_domain)
+            result['changed'] = True
+        else:
+            protection_domain['id'] = pd_details['id']
+            result['changed'], result['protection_domain_details'] = self.update(
+                protection_domain, pd_details)
+
+        self.module.exit_json(**result)
+
+
+def main():
+    """ Create PowerFlex protection domain object and perform actions on it
+        based on user input from playbook"""
+    obj = PowerFlexProtectionDomainV2()
+    obj.exec()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/replication_consistency_group.py
+++ b/plugins/modules/replication_consistency_group.py
@@ -59,11 +59,6 @@ options:
     - This parameter is supported for version 3.6 and above.
     choices: ['Active', 'Inactive']
     type: str
-  pause:
-    description:
-    - Pause or resume the RCG.
-    - This parameter is deprecated. Use rcg_state instead.
-    type: bool
   rcg_state:
     description:
     - Specify an action for RCG.
@@ -81,11 +76,6 @@ options:
   force:
     description:
     - Force switchover the RCG.
-    type: bool
-  freeze:
-    description:
-    - Freeze or unfreeze the RCG.
-    - This parameter is deprecated. Use rcg_state instead.
     type: bool
   pause_mode:
     description:
@@ -923,23 +913,9 @@ class PowerFlexReplicationConsistencyGroup(object):
         :rtype: (bool,bool)
         """
         rcg_state = self.module.params['rcg_state']
-        pause = self.module.params['pause']
-        freeze = self.module.params['freeze']
 
-        if pause is not None:
-            self.module.deprecate(
-                msg="Use 'rcg_state' param instead of 'pause'",
-                version="3.0.0",
-                collection_name="dellemc.powerflex"
-            )
-
-        if freeze is not None:
-            self.module.deprecate(
-                msg="Use 'rcg_state' param instead of 'freeze'",
-                version="3.0.0",
-                collection_name="dellemc.powerflex"
-            )
-
+        pause = None
+        freeze = None
         if rcg_state == 'pause':
             pause = True
         if rcg_state == 'resume':
@@ -1012,7 +988,8 @@ class PowerFlexReplicationConsistencyGroup(object):
     def validate_input(self, rcg_params):
         try:
             api_version = self.powerflex_conn.system.get()[0]['mdmCluster']['master']['versionInfo']
-            if rcg_params['activity_mode'] is not None and utils.is_version_less_than_3_6(api_version):
+            if rcg_params['activity_mode'] is not None and utils.is_version_less(
+                    utils.parse_version(api_version), '3.6'):
                 self.module.fail_json(msg='activity_mode is supported only from version 3.6 and above')
             params = ['rcg_name', 'new_rcg_name']
             for param in params:
@@ -1095,8 +1072,6 @@ def get_powerflex_replication_consistency_group_parameters():
         rpo=dict(type='int'), protection_domain_id=dict(),
         protection_domain_name=dict(), new_rcg_name=dict(),
         activity_mode=dict(choices=['Active', 'Inactive']),
-        pause=dict(type='bool', removed_in_version='3.0.0', removed_from_collection='dellemc.powerflex'),
-        freeze=dict(type='bool', removed_in_version='3.0.0', removed_from_collection='dellemc.powerflex'),
         force=dict(type='bool'),
         rcg_state=dict(choices=['failover', 'reverse',
                                 'restore', 'switchover',

--- a/plugins/modules/storagepool.py
+++ b/plugins/modules/storagepool.py
@@ -752,7 +752,7 @@ storage_pool_details:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
-    import PowerFlexBase
+    import PowerFlexBase, powerflex_compatibility
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.configuration \
     import Configuration
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
@@ -761,6 +761,7 @@ from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
 LOG = utils.get_logger('storagepool')
 
 
+@powerflex_compatibility(min_ver='3.6', max_ver='5.0', successor='storagepool_v2')
 class PowerFlexStoragePool(PowerFlexBase):
     """Class with StoragePool operations"""
 
@@ -781,8 +782,9 @@ class PowerFlexStoragePool(PowerFlexBase):
             'required_one_of': required_one_of
         }
         super().__init__(AnsibleModule, ansible_module_params)
+        super().check_module_compatibility()
 
-        utils.ensure_required_libs(self.module)
+        # utils.ensure_required_libs(self.module)
         self.result = dict(
             changed=False,
             storage_pool_details={}
@@ -827,7 +829,8 @@ class PowerFlexStoragePool(PowerFlexBase):
                     self.module.fail_json(msg=err_msg)
                 elif len(pool_details) == 1:
                     pool_details = pool_details[0]
-                    statistics = self.powerflex_conn.storage_pool.get_statistics(pool_details['id'])
+                    statistics = self.powerflex_conn.storage_pool.get_statistics(
+                        pool_details['id'])
                     pool_details['statistics'] = statistics if statistics else {}
                     pd_id = pool_details['protectionDomainId']
                     pd_name = self.get_protection_domain(
@@ -926,7 +929,8 @@ class PowerFlexStoragePool(PowerFlexBase):
                         validate=pool_params['persistent_checksum']['validate_on_read'],
                         builder_limit=pool_params['persistent_checksum']['builder_limit'])
 
-            pool_details = self.get_storage_pool(storage_pool_id=pool_details['id'])
+            pool_details = self.get_storage_pool(
+                storage_pool_id=pool_details['id'])
             return pool_details
 
         except Exception as e:
@@ -968,11 +972,13 @@ class PowerFlexStoragePool(PowerFlexBase):
 
         if pool_params['rebalance_io_priority_policy']['concurrent_ios_per_device'] is not None and \
                 pool_params['rebalance_io_priority_policy']['concurrent_ios_per_device'] != pool_details['rebalanceIoPriorityNumOfConcurrentIosPerDevice']:
-            policy_dict['concurrent_ios'] = str(pool_params['rebalance_io_priority_policy']['concurrent_ios_per_device'])
+            policy_dict['concurrent_ios'] = str(
+                pool_params['rebalance_io_priority_policy']['concurrent_ios_per_device'])
 
         if pool_params['rebalance_io_priority_policy']['bw_limit_per_device'] is not None and \
                 pool_params['rebalance_io_priority_policy']['bw_limit_per_device'] != pool_details['rebalanceIoPriorityBwLimitPerDeviceInKbps']:
-            policy_dict['bw_limit'] = str(pool_params['rebalance_io_priority_policy']['bw_limit_per_device'])
+            policy_dict['bw_limit'] = str(
+                pool_params['rebalance_io_priority_policy']['bw_limit_per_device'])
 
         if policy_dict['policy'] is None and (policy_dict['concurrent_ios'] is not None or policy_dict['bw_limit'] is not None):
             policy_dict['policy'] = pool_details['rebalanceIoPriorityPolicy']
@@ -998,12 +1004,14 @@ class PowerFlexStoragePool(PowerFlexBase):
         if pool_params['vtree_migration_io_priority_policy']['concurrent_ios_per_device'] is not None and \
                 pool_params['vtree_migration_io_priority_policy']['concurrent_ios_per_device'] != \
                 pool_details['vtreeMigrationIoPriorityNumOfConcurrentIosPerDevice']:
-            policy_dict['concurrent_ios'] = str(pool_params['vtree_migration_io_priority_policy']['concurrent_ios_per_device'])
+            policy_dict['concurrent_ios'] = str(
+                pool_params['vtree_migration_io_priority_policy']['concurrent_ios_per_device'])
 
         if pool_params['vtree_migration_io_priority_policy']['bw_limit_per_device'] is not None and \
                 pool_params['vtree_migration_io_priority_policy']['bw_limit_per_device'] != \
                 pool_details['vtreeMigrationIoPriorityBwLimitPerDeviceInKbps']:
-            policy_dict['bw_limit'] = str(pool_params['vtree_migration_io_priority_policy']['bw_limit_per_device'])
+            policy_dict['bw_limit'] = str(
+                pool_params['vtree_migration_io_priority_policy']['bw_limit_per_device'])
 
         if policy_dict['policy'] is None and (policy_dict['concurrent_ios'] is not None or policy_dict['bw_limit'] is not None):
             policy_dict['policy'] = pool_details['vtreeMigrationIoPriorityPolicy']
@@ -1030,12 +1038,14 @@ class PowerFlexStoragePool(PowerFlexBase):
         if pool_params['protected_maintenance_mode_io_priority_policy']['concurrent_ios_per_device'] is not None and \
                 pool_params['protected_maintenance_mode_io_priority_policy']['concurrent_ios_per_device'] != \
                 pool_details['protectedMaintenanceModeIoPriorityNumOfConcurrentIosPerDevice']:
-            policy_dict['concurrent_ios'] = str(pool_params['protected_maintenance_mode_io_priority_policy']['concurrent_ios_per_device'])
+            policy_dict['concurrent_ios'] = str(
+                pool_params['protected_maintenance_mode_io_priority_policy']['concurrent_ios_per_device'])
 
         if pool_params['protected_maintenance_mode_io_priority_policy']['bw_limit_per_device'] is not None and \
                 pool_params['protected_maintenance_mode_io_priority_policy']['bw_limit_per_device'] != \
                 pool_details['protectedMaintenanceModeIoPriorityBwLimitPerDeviceInKbps']:
-            policy_dict['bw_limit'] = str(pool_params['protected_maintenance_mode_io_priority_policy']['bw_limit_per_device'])
+            policy_dict['bw_limit'] = str(
+                pool_params['protected_maintenance_mode_io_priority_policy']['bw_limit_per_device'])
 
         if policy_dict['policy'] is None and (policy_dict['concurrent_ios'] is not None or policy_dict['bw_limit'] is not None):
             policy_dict['policy'] = pool_details['protectedMaintenanceModeIoPriorityPolicy']
@@ -1051,18 +1061,22 @@ class PowerFlexStoragePool(PowerFlexBase):
         threshold = dict()
         if pool_params['cap_alert_thresholds']['high_threshold'] is not None and pool_params['cap_alert_thresholds'][
                 'high_threshold'] != pool_details['capacityAlertHighThreshold']:
-            threshold['high'] = str(pool_params['cap_alert_thresholds']['high_threshold'])
+            threshold['high'] = str(
+                pool_params['cap_alert_thresholds']['high_threshold'])
             modify = True
         if pool_params['cap_alert_thresholds']['critical_threshold'] is not None and \
                 pool_params['cap_alert_thresholds']['critical_threshold'] != pool_details[
                 'capacityAlertCriticalThreshold']:
-            threshold['critical'] = str(pool_params['cap_alert_thresholds']['critical_threshold'])
+            threshold['critical'] = str(
+                pool_params['cap_alert_thresholds']['critical_threshold'])
             modify = True
         if modify is True:
             if 'high' not in threshold:
-                threshold['high'] = str(pool_details['capacityAlertHighThreshold'])
+                threshold['high'] = str(
+                    pool_details['capacityAlertHighThreshold'])
             if 'critical' not in threshold:
-                threshold['critical'] = str(pool_details['capacityAlertCriticalThreshold'])
+                threshold['critical'] = str(
+                    pool_details['capacityAlertCriticalThreshold'])
 
         return threshold
 
@@ -1081,7 +1095,8 @@ def get_powerflex_storagepool_parameters():
         use_rmcache=dict(required=False, type='bool'),
         enable_zero_padding=dict(type='bool'),
         rep_cap_max_ratio=dict(type='int'),
-        rmcache_write_handling_mode=dict(choices=['Cached', 'Passthrough'], default='Cached'),
+        rmcache_write_handling_mode=dict(
+            choices=['Cached', 'Passthrough'], default='Cached'),
         spare_percentage=dict(type='int'),
         enable_rebalance=dict(type='bool'),
         enable_fragmentation=dict(type='bool'),
@@ -1092,11 +1107,13 @@ def get_powerflex_storagepool_parameters():
             high_threshold=dict(type='int'),
             critical_threshold=dict(type='int'))),
         protected_maintenance_mode_io_priority_policy=dict(type='dict', options=dict(
-            policy=dict(choices=['unlimited', 'limitNumOfConcurrentIos', 'favorAppIos'], default='limitNumOfConcurrentIos'),
+            policy=dict(choices=['unlimited', 'limitNumOfConcurrentIos',
+                        'favorAppIos'], default='limitNumOfConcurrentIos'),
             concurrent_ios_per_device=dict(type='int'),
             bw_limit_per_device=dict(type='int'))),
         rebalance_io_priority_policy=dict(type='dict', options=dict(
-            policy=dict(choices=['unlimited', 'limitNumOfConcurrentIos', 'favorAppIos'], default='favorAppIos'),
+            policy=dict(choices=[
+                        'unlimited', 'limitNumOfConcurrentIos', 'favorAppIos'], default='favorAppIos'),
             concurrent_ios_per_device=dict(type='int'),
             bw_limit_per_device=dict(type='int'))),
         vtree_migration_io_priority_policy=dict(type='dict', options=dict(
@@ -1113,7 +1130,8 @@ def get_powerflex_storagepool_parameters():
 class StoragePoolExitHandler():
     def handle(self, pool_obj, pool_details):
         if pool_details:
-            pool_details = pool_obj.get_storage_pool(storage_pool_id=pool_details['id'])
+            pool_details = pool_obj.get_storage_pool(
+                storage_pool_id=pool_details['id'])
         pool_obj.result['storage_pool_details'] = pool_details
 
         pool_obj.module.exit_json(**pool_obj.result)
@@ -1172,7 +1190,8 @@ class StoragePoolModifyRebalanceIOPriorityPolicyHandler():
                                 bw_limit_per_device=policy_dict['bw_limit'])
                         pool_obj.result['changed'] = True
 
-            StoragePoolModifyPersistentChecksumHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyPersistentChecksumHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify rebalance IO Priority Policy failed "
@@ -1199,7 +1218,8 @@ class StoragePoolSetVtreeMigrationIOPriorityPolicyHandler():
                                 bw_limit_per_device=policy_dict['bw_limit'])
                         pool_obj.result['changed'] = True
 
-            StoragePoolModifyRebalanceIOPriorityPolicyHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyRebalanceIOPriorityPolicyHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Set Vtree Migration I/O Priority Policy operation failed "
@@ -1226,7 +1246,8 @@ class StoragePoolSetProtectedMaintenanceModeIOPriorityPolicyHandler():
                                 bw_limit_per_device=policy_dict['bw_limit'])
                         pool_obj.result['changed'] = True
 
-            StoragePoolSetVtreeMigrationIOPriorityPolicyHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolSetVtreeMigrationIOPriorityPolicyHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Set Protected Maintenance Mode IO Priority Policy operation failed "
@@ -1252,7 +1273,8 @@ class StoragePoolModifyCapacityAlertThresholdsHandler():
                                 cap_alert_critical_threshold=threshold['critical'])
                         pool_obj.result['changed'] = True
 
-            StoragePoolSetProtectedMaintenanceModeIOPriorityPolicyHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolSetProtectedMaintenanceModeIOPriorityPolicyHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify Capacity Alert Thresholds operation failed "
@@ -1272,7 +1294,8 @@ class StoragePoolModifyRebuildRebalanceParallelismLimitHandler():
                             pool_details['id'], str(pool_params['parallel_rebuild_rebalance_limit']))
                     pool_obj.result['changed'] = True
 
-            StoragePoolModifyCapacityAlertThresholdsHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyCapacityAlertThresholdsHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify Rebuild/Rebalance Parallelism Limit operation failed "
@@ -1292,7 +1315,8 @@ class StoragePoolModifyRMCacheWriteHandlingModeHandler():
                             pool_details['id'], pool_params['rmcache_write_handling_mode'])
                     pool_obj.result['changed'] = True
 
-            StoragePoolModifyRebuildRebalanceParallelismLimitHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyRebuildRebalanceParallelismLimitHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify RMCache Write Handling Mode failed "
@@ -1311,7 +1335,8 @@ class StoragePoolModifySparePercentageHandler():
                             pool_details['id'], str(pool_params['spare_percentage']))
                     pool_obj.result['changed'] = True
 
-            StoragePoolModifyRMCacheWriteHandlingModeHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyRMCacheWriteHandlingModeHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify Spare Percentage operation failed "
@@ -1330,7 +1355,8 @@ class StoragePoolEnableFragmentationHandler():
                             pool_details['id'], pool_params['enable_fragmentation'])
                     pool_obj.result['changed'] = True
 
-            StoragePoolModifySparePercentageHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifySparePercentageHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
 
@@ -1350,7 +1376,8 @@ class StoragePoolEnableRebuildHandler():
                             pool_details['id'], pool_params['enable_rebuild'])
                     pool_obj.result['changed'] = True
 
-            StoragePoolEnableFragmentationHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolEnableFragmentationHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Enable/Disable Rebuild operation failed "
@@ -1407,7 +1434,8 @@ class StoragePoolEnableZeroPaddingHandler():
                             pool_details['id'], pool_params['enable_zero_padding'])
                     pool_obj.result['changed'] = True
 
-            StoragePoolModifyRepCapMaxRatioHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolModifyRepCapMaxRatioHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Enable/Disable zero padding operation failed "
@@ -1426,7 +1454,8 @@ class StoragePoolUseRFCacheHandler():
                             pool_details['id'], pool_params['use_rfcache'])
                     pool_obj.result['changed'] = True
 
-            StoragePoolEnableZeroPaddingHandler().handle(pool_obj, pool_params, pool_details)
+            StoragePoolEnableZeroPaddingHandler().handle(
+                pool_obj, pool_params, pool_details)
 
         except Exception as e:
             error_msg = (f"Modify RF cache operation failed "
@@ -1460,7 +1489,8 @@ class StoragePoolRenameHandler():
             if pool_params['state'] == 'present' and pool_details:
                 if pool_params['storage_pool_new_name'] is not None and pool_params['storage_pool_new_name'] != pool_details['name']:
                     if not pool_obj.module.check_mode:
-                        pool_obj.powerflex_conn.storage_pool.rename(pool_details['id'], pool_params['storage_pool_new_name'])
+                        pool_obj.powerflex_conn.storage_pool.rename(
+                            pool_details['id'], pool_params['storage_pool_new_name'])
                     pool_obj.result['changed'] = True
 
             StoragePoolUseRMCacheHandler().handle(pool_obj, pool_params, pool_details)
@@ -1511,7 +1541,8 @@ class StoragePoolCreateHandler():
 
             pool_obj.result['changed'] = True
 
-        StoragePoolModifyMediaTypeHandler().handle(pool_obj, pool_params, pool_details, media_type)
+        StoragePoolModifyMediaTypeHandler().handle(
+            pool_obj, pool_params, pool_details, media_type)
 
 
 class StoragePoolHandler():
@@ -1529,7 +1560,8 @@ class StoragePoolHandler():
                                                  storage_pool_name=pool_params['storage_pool_name'],
                                                  pd_id=pd_id)
         pool_obj.verify_protection_domain(pool_details=pool_details)
-        StoragePoolCreateHandler().handle(pool_obj, pool_params, pool_details, pd_id, media_type)
+        StoragePoolCreateHandler().handle(pool_obj, pool_params,
+                                          pool_details, pd_id, media_type)
 
 
 def main():

--- a/plugins/modules/storagepool_v2.py
+++ b/plugins/modules/storagepool_v2.py
@@ -1,0 +1,790 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2021-25, Dell Technologies
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing storage pool on Dell Technologies (Dell) PowerFlex 5.x"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: storagepool_v2
+version_added: '3.0.0'
+short_description: Managing storage pool on Dell PowerFlex 5.x
+
+description:
+- Dell PowerFlex storage pool module includes getting the details of
+  storage pool, creating a new storage pool, and modifying the attribute of
+  a storage pool.
+
+extends_documentation_fragment:
+  - dellemc.powerflex.powerflex
+
+author:
+- Luis Liu (@vangork) <ansible.team@dell.com>
+
+options:
+  storage_pool_name:
+    description:
+    - The name of the storage pool.
+    - If more than one storage pool is found with the same name then
+      protection domain id/name is required to perform the task.
+    - Mutually exclusive with I(storage_pool_id).
+    type: str
+  storage_pool_id:
+    description:
+    - The id of the storage pool.
+    - It is auto generated, hence should not be provided during
+      creation of a storage pool.
+    - Mutually exclusive with I(storage_pool_name).
+    type: str
+  storage_pool_new_name:
+    description:
+    - New name for the storage pool can be provided.
+    - This parameter is used for renaming the storage pool.
+    type: str
+  protection_domain_name:
+    description:
+    - The name of the protection domain.
+    - During creation of a pool, either protection domain name or id must be
+      mentioned.
+    - Mutually exclusive with I(protection_domain_id).
+    type: str
+  protection_domain_id:
+    description:
+    - The id of the protection domain.
+    - During creation of a pool, either protection domain name or id must
+      be mentioned.
+    - Mutually exclusive with I(protection_domain_name).
+    type: str
+  device_group_id:
+    description:
+      - The ID of the device group.
+    required: false
+    type: str
+  cap_alert_thresholds:
+    description:
+      - The capacity alert thresholds.
+    required: false
+    type: dict
+    suboptions:
+      high_threshold:
+        description:
+          - The high threshold.
+        required: false
+        type: int
+      critical_threshold:
+        description:
+          - The critical threshold.
+        required: false
+        type: int
+  compression_method:
+    description:
+      - The compression method.
+    required: false
+    type: str
+    choices: ['None', 'Normal']
+  over_provisioning_factor:
+    description:
+      - The over-provisioning factor.
+    required: false
+    type: int
+  physical_size_gb:
+    description:
+      - The physical size in GB.
+    required: false
+    type: int
+  protection_scheme:
+    description:
+      - The protection scheme.
+    required: false
+    type: str
+    choices: ['TwoPlusTwo', 'EightPlusTwo']
+  state:
+    description:
+      - The state of the storage pool. Can be 'present' or 'absent'.
+    required: true
+    choices: ['present', 'absent']
+    type: str
+notes:
+  - This module is supported on Dell PowerFlex 5.x and later versions.
+  - The I(check_mode) is supported.
+'''
+
+EXAMPLES = r'''
+- name: Get the details of storage pool by name
+  dellemc.powerflex.storagepool_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    storage_pool_name: "sample_pool_name"
+    protection_domain_name: "sample_protection_domain"
+    state: "present"
+
+- name: Get the details of storage pool by id
+  dellemc.powerflex.storagepool_v2:
+    hostname: "{{hostname}}"
+    username: "{{username}}"
+    password: "{{password}}"
+    validate_certs: "{{validate_certs}}"
+    storage_pool_id: "abcd1234ab12r"
+    state: "present"
+
+- name: Create a new Storage pool
+  dellemc.powerflex.storagepool_v2:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    storage_pool_name: "{{ pool_name }}"
+    protection_domain_name: "{{ protection_domain_name }}"
+    cap_alert_thresholds:
+      high_threshold: 80
+      critical_threshold: 90
+    compression_method: Normal
+    over_provisioning_factor: 2
+    physical_size_gb: 100
+    protection_scheme: TwoPlusTwo
+    state: "present"
+
+- name: Modify a Storage pool by name
+  dellemc.powerflex.storagepool_v2:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    storage_pool_name: "{{ pool_name }}"
+    protection_domain_name: "{{ protection_domain_name }}"
+    storage_pool_new_name: "pool_name_new"
+    cap_alert_thresholds:
+      high_threshold: 85
+      critical_threshold: 95
+    compression_method: None
+    state: "present"
+'''
+
+RETURN = r'''
+changed:
+    description: Whether or not the resource has changed.
+    returned: always
+    type: bool
+    sample: 'false'
+storage_pool_details:
+    description: Details of the storage pool.
+    returned: When storage pool exists
+    type: dict
+    contains:
+        mediaType:
+            description: Type of devices in the storage pool.
+            type: str
+        useRfcache:
+            description: Enable/Disable RFcache on a specific storage pool.
+            type: bool
+        useRmcache:
+            description: Enable/Disable RMcache on a specific storage pool.
+            type: bool
+        id:
+            description: ID of the storage pool under protection domain.
+            type: str
+        name:
+            description: Name of the storage pool under protection domain.
+            type: str
+        protectionDomainId:
+            description: ID of the protection domain in which pool resides.
+            type: str
+        protectionDomainName:
+            description: Name of the protection domain in which pool resides.
+            type: str
+        "statistics":
+            description: Statistics details of the storage pool.
+            type: dict
+            contains:
+                "capacityInUseInKb":
+                    description: Total capacity of the storage pool.
+                    type: str
+                "unusedCapacityInKb":
+                    description: Unused capacity of the storage pool.
+                    type: str
+                "deviceIds":
+                    description: Device Ids of the storage pool.
+                    type: list
+    sample: {
+        "addressSpaceUsage": "Normal",
+        "addressSpaceUsageType": "DeviceCapacityLimit",
+        "backgroundScannerBWLimitKBps": 3072,
+        "backgroundScannerMode": "DataComparison",
+        "bgScannerCompareErrorAction": "ReportAndFix",
+        "bgScannerReadErrorAction": "ReportAndFix",
+        "capacityAlertCriticalThreshold": 90,
+        "capacityAlertHighThreshold": 80,
+        "capacityUsageState": "Normal",
+        "capacityUsageType": "NetCapacity",
+        "checksumEnabled": false,
+        "compressionMethod": "Invalid",
+        "dataLayout": "MediumGranularity",
+        "externalAccelerationType": "None",
+        "fglAccpId": null,
+        "fglExtraCapacity": null,
+        "fglMaxCompressionRatio": null,
+        "fglMetadataSizeXx100": null,
+        "fglNvdimmMetadataAmortizationX100": null,
+        "fglNvdimmWriteCacheSizeInMb": null,
+        "fglOverProvisioningFactor": null,
+        "fglPerfProfile": null,
+        "fglWriteAtomicitySize": null,
+        "fragmentationEnabled": true,
+        "id": "e0d8f6c900000000",
+        "links": [
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000",
+                "rel": "self"
+            },
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000
+                        /relationships/Statistics",
+                "rel": "/api/StoragePool/relationship/Statistics"
+            },
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000
+                        /relationships/SpSds",
+                "rel": "/api/StoragePool/relationship/SpSds"
+            },
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000
+                        /relationships/Volume",
+                "rel": "/api/StoragePool/relationship/Volume"
+            },
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000
+                        /relationships/Device",
+                "rel": "/api/StoragePool/relationship/Device"
+            },
+            {
+                "href": "/api/instances/StoragePool::e0d8f6c900000000
+                        /relationships/VTree",
+                "rel": "/api/StoragePool/relationship/VTree"
+            },
+            {
+                "href": "/api/instances/ProtectionDomain::9300c1f900000000",
+                "rel": "/api/parent/relationship/protectionDomainId"
+            }
+        ],
+        "statistics": {
+                "BackgroundScannedInMB": 3466920,
+                "activeBckRebuildCapacityInKb": 0,
+                "activeEnterProtectedMaintenanceModeCapacityInKb": 0,
+                "aggregateCompressionLevel": "Uncompressed",
+                "atRestCapacityInKb": 1248256,
+                "backgroundScanCompareErrorCount": 0,
+                "backgroundScanFixedCompareErrorCount": 0,
+                "bckRebuildReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "bckRebuildWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "capacityAvailableForVolumeAllocationInKb": 369098752,
+                "capacityInUseInKb": 2496512,
+                "capacityInUseNoOverheadInKb": 2496512,
+                "capacityLimitInKb": 845783040,
+                "compressedDataCompressionRatio": 0.0,
+                "compressionRatio": 1.0,
+                "currentFglMigrationSizeInKb": 0,
+                "deviceIds": [
+                ],
+                "enterProtectedMaintenanceModeCapacityInKb": 0,
+                "enterProtectedMaintenanceModeReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "enterProtectedMaintenanceModeWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "exitProtectedMaintenanceModeReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "exitProtectedMaintenanceModeWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "exposedCapacityInKb": 0,
+                "failedCapacityInKb": 0,
+                "fwdRebuildReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "fwdRebuildWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "inMaintenanceCapacityInKb": 0,
+                "inMaintenanceVacInKb": 0,
+                "inUseVacInKb": 184549376,
+                "inaccessibleCapacityInKb": 0,
+                "logWrittenBlocksInKb": 0,
+                "maxCapacityInKb": 845783040,
+                "migratingVolumeIds": [
+                ],
+                "migratingVtreeIds": [
+                ],
+                "movingCapacityInKb": 0,
+                "netCapacityInUseInKb": 1248256,
+                "normRebuildCapacityInKb": 0,
+                "normRebuildReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "normRebuildWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "numOfDeviceAtFaultRebuilds": 0,
+                "numOfDevices": 3,
+                "numOfIncomingVtreeMigrations": 0,
+                "numOfVolumes": 8,
+                "numOfVolumesInDeletion": 0,
+                "numOfVtrees": 8,
+                "overallUsageRatio": 73.92289,
+                "pendingBckRebuildCapacityInKb": 0,
+                "pendingEnterProtectedMaintenanceModeCapacityInKb": 0,
+                "pendingExitProtectedMaintenanceModeCapacityInKb": 0,
+                "pendingFwdRebuildCapacityInKb": 0,
+                "pendingMovingCapacityInKb": 0,
+                "pendingMovingInBckRebuildJobs": 0,
+                "persistentChecksumBuilderProgress": 100.0,
+                "persistentChecksumCapacityInKb": 414720,
+                "primaryReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "primaryReadFromDevBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "primaryReadFromRmcacheBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "primaryVacInKb": 92274688,
+                "primaryWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "protectedCapacityInKb": 2496512,
+                "protectedVacInKb": 184549376,
+                "provisionedAddressesInKb": 2496512,
+                "rebalanceCapacityInKb": 0,
+                "rebalanceReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "rebalanceWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "rfacheReadHit": 0,
+                "rfacheWriteHit": 0,
+                "rfcacheAvgReadTime": 0,
+                "rfcacheAvgWriteTime": 0,
+                "rfcacheIoErrors": 0,
+                "rfcacheIosOutstanding": 0,
+                "rfcacheIosSkipped": 0,
+                "rfcacheReadMiss": 0,
+                "rmPendingAllocatedInKb": 0,
+                "rmPendingThickInKb": 0,
+                "rplJournalCapAllowed": 0,
+                "rplTotalJournalCap": 0,
+                "rplUsedJournalCap": 0,
+                "secondaryReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "secondaryReadFromDevBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "secondaryReadFromRmcacheBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "secondaryVacInKb": 92274688,
+                "secondaryWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "semiProtectedCapacityInKb": 0,
+                "semiProtectedVacInKb": 0,
+                "snapCapacityInUseInKb": 0,
+                "snapCapacityInUseOccupiedInKb": 0,
+                "snapshotCapacityInKb": 0,
+                "spSdsIds": [
+                    "abdfe71b00030001",
+                    "abdce71d00040001",
+                    "abdde71e00050001"
+                ],
+                "spareCapacityInKb": 84578304,
+                "targetOtherLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "targetReadLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "targetWriteLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "tempCapacityInKb": 0,
+                "tempCapacityVacInKb": 0,
+                "thickCapacityInUseInKb": 0,
+                "thinAndSnapshotRatio": 73.92289,
+                "thinCapacityAllocatedInKm": 184549376,
+                "thinCapacityInUseInKb": 0,
+                "thinUserDataCapacityInKb": 2496512,
+                "totalFglMigrationSizeInKb": 0,
+                "totalReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "totalWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "trimmedUserDataCapacityInKb": 0,
+                "unreachableUnusedCapacityInKb": 0,
+                "unusedCapacityInKb": 758708224,
+                "userDataCapacityInKb": 2496512,
+                "userDataCapacityNoTrimInKb": 2496512,
+                "userDataReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "userDataSdcReadLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "userDataSdcTrimLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "userDataSdcWriteLatency": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "userDataTrimBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "userDataWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "volMigrationReadBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "volMigrationWriteBwc": {
+                    "numOccured": 0,
+                    "numSeconds": 0,
+                    "totalWeightInKb": 0
+                },
+                "volumeAddressSpaceInKb": 922XXXXX,
+                "volumeAllocationLimitInKb": 3707XXXXX,
+                "volumeIds": [
+                    "456afc7900XXXXXXXX"
+                ],
+                "vtreeAddresSpaceInKb": 92274688,
+                "vtreeIds": [
+                    "32b1681bXXXXXXXX",
+                ]
+        },
+        "mediaType": "HDD",
+        "name": "pool1",
+        "numOfParallelRebuildRebalanceJobsPerDevice": 2,
+        "persistentChecksumBuilderLimitKb": 3072,
+        "persistentChecksumEnabled": true,
+        "persistentChecksumState": "Protected",
+        "persistentChecksumValidateOnRead": false,
+        "protectedMaintenanceModeIoPriorityAppBwPerDeviceThresholdInKbps": null,
+        "protectedMaintenanceModeIoPriorityAppIopsPerDeviceThreshold": null,
+        "protectedMaintenanceModeIoPriorityBwLimitPerDeviceInKbps": 10240,
+        "protectedMaintenanceModeIoPriorityNumOfConcurrentIosPerDevice": 1,
+        "protectedMaintenanceModeIoPriorityPolicy": "limitNumOfConcurrentIos",
+        "protectedMaintenanceModeIoPriorityQuietPeriodInMsec": null,
+        "protectionDomainId": "9300c1f900000000",
+        "protectionDomainName": "domain1",
+        "rebalanceEnabled": true,
+        "rebalanceIoPriorityAppBwPerDeviceThresholdInKbps": null,
+        "rebalanceIoPriorityAppIopsPerDeviceThreshold": null,
+        "rebalanceIoPriorityBwLimitPerDeviceInKbps": 10240,
+        "rebalanceIoPriorityNumOfConcurrentIosPerDevice": 1,
+        "rebalanceIoPriorityPolicy": "favorAppIos",
+        "rebalanceIoPriorityQuietPeriodInMsec": null,
+        "rebuildEnabled": true,
+        "rebuildIoPriorityAppBwPerDeviceThresholdInKbps": null,
+        "rebuildIoPriorityAppIopsPerDeviceThreshold": null,
+        "rebuildIoPriorityBwLimitPerDeviceInKbps": 10240,
+        "rebuildIoPriorityNumOfConcurrentIosPerDevice": 1,
+        "rebuildIoPriorityPolicy": "limitNumOfConcurrentIos",
+        "rebuildIoPriorityQuietPeriodInMsec": null,
+        "replicationCapacityMaxRatio": 32,
+        "rmcacheWriteHandlingMode": "Cached",
+        "sparePercentage": 10,
+        "useRfcache": false,
+        "useRmcache": false,
+        "vtreeMigrationIoPriorityAppBwPerDeviceThresholdInKbps": null,
+        "vtreeMigrationIoPriorityAppIopsPerDeviceThreshold": null,
+        "vtreeMigrationIoPriorityBwLimitPerDeviceInKbps": 10240,
+        "vtreeMigrationIoPriorityNumOfConcurrentIosPerDevice": 1,
+        "vtreeMigrationIoPriorityPolicy": "favorAppIos",
+        "vtreeMigrationIoPriorityQuietPeriodInMsec": null,
+        "zeroPaddingEnabled": true
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import PowerFlexBase, powerflex_compatibility
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
+    import utils
+
+
+LOG = utils.get_logger('storagepool_v2')
+
+
+@powerflex_compatibility(min_ver='5.0', predecessor='storagepool')
+class PowerFlexStoragePoolV2(PowerFlexBase):
+    """Class with storage pool operations"""
+
+    def __init__(self):
+        """ Define all parameters required by this module"""
+        argument_spec = dict(
+            storage_pool_name=dict(required=False, type='str'),
+            storage_pool_id=dict(required=False, type='str'),
+            storage_pool_new_name=dict(required=False, type='str'),
+            protection_domain_name=dict(required=False, type='str'),
+            protection_domain_id=dict(type='str'),
+            device_group_id=dict(type='str'),
+            cap_alert_thresholds=dict(type='dict', options=dict(
+                high_threshold=dict(type='int'),
+                critical_threshold=dict(type='int'),
+            )),
+            compression_method=dict(type='str', choices=['None', 'Normal']),
+            over_provisioning_factor=dict(type='int'),
+            physical_size_gb=dict(type='int'),
+            protection_scheme=dict(type='str', choices=[
+                                   'TwoPlusTwo', 'EightPlusTwo']),
+            state=dict(required=True, type='str',
+                       choices=['present', 'absent']),
+        )
+
+        required_if = [
+            ('storage_pool_id', None, ('protection_domain_id', 'storage_pool_name')),
+        ]
+        module_params = {
+            'argument_spec': argument_spec,
+            'supports_check_mode': False,
+            'required_if': required_if,
+        }
+
+        super().__init__(AnsibleModule, module_params)
+        super().check_module_compatibility()
+
+    def get(self, storage_pool_id, protection_domain_id, storage_pool_name):
+        """
+        Get storage pool details
+        :param id: Storage pool ID
+        :type id: str
+        :param protection_domain_id: Protection domain ID
+        :type protection_domain_id: str
+        :param name: Storage pool name
+        :type name: str
+        :return: Storage pool details
+        """
+        name_or_id = storage_pool_id if storage_pool_id else storage_pool_name
+        try:
+            if storage_pool_id:
+                sp_details = self.powerflex_conn.storage_pool.get_by_id(
+                    storage_pool_id)
+            else:
+                sp_details = self.powerflex_conn.storage_pool.get_by_name(
+                    protection_domain_id, storage_pool_name)
+            return sp_details
+        except Exception as e:
+            error_msg = "Failed to get the storage pool {0} with error " \
+                "{1}".format(name_or_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def delete(self, storage_pool_id):
+        """
+        Delete storage pool
+        :param storage_pool_id: Storage pool ID
+        :type storage_pool_id: str
+        :rtype: None
+        """
+        try:
+            self.powerflex_conn.storage_pool.delete(storage_pool_id)
+            LOG.info("Storage pool deleted successfully.")
+        except Exception as e:
+            error_msg = "Delete storage pool '%s' operation failed" \
+                        " with error '%s'" % (storage_pool_id, str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def create(self, storage_pool):
+        """
+        Create storage pool
+        :param storage_pool: Dict of the storage pool
+        :type storage_pool: dict
+        :return: Dict representation of the created storage pool
+        """
+        try:
+            LOG.info("Creating storage pool with name: %s ",
+                     storage_pool['name'])
+            return self.powerflex_conn.storage_pool.create(storage_pool)
+        except Exception as e:
+            error_msg = "Create storage pool '%s' operation failed" \
+                        " with error '%s'" % (storage_pool['name'], str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg)
+
+    def update(self, storage_pool, current_storage_pool=None):
+        """
+        Modify storage pool attributes
+        :param storage_pool: Dictionary containing the attributes of
+                            storage pool which are to be updated
+        :type storage_pool: dict
+        :return: Bool to indicate if storage pool is updated,
+                 Dict representation of the updated storage pool
+        """
+        try:
+            LOG.info("Updating storage pool with id: %s ",
+                     storage_pool['storage_pool_id'])
+            return self.powerflex_conn.storage_pool.update(storage_pool, current_storage_pool)
+        except Exception as e:
+            err_msg = "Failed to update the storage pool {0}" \
+                " with error {1}".format(
+                    storage_pool['storage_pool_id'], str(e))
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg)
+
+    def exec(self):
+        """
+        Perform different actions on protection domain based on parameters
+        passed in the playbook
+        """
+        storage_pool_id = self.module.params['storage_pool_id']
+        storage_pool_name = self.module.params['storage_pool_name']
+        protection_domain_id = self.module.params['protection_domain_id']
+        device_group_id = self.module.params['device_group_id']
+        cap_alert_thresholds = self.module.params['cap_alert_thresholds']
+        cap_alert_high_threshold = None if cap_alert_thresholds is None else cap_alert_thresholds[
+            'high_threshold']
+        cap_alert_critical_threshold = None if cap_alert_thresholds is None else cap_alert_thresholds[
+            'critical_threshold']
+        over_provisioning_factor = self.module.params['over_provisioning_factor']
+        physical_size_gb = self.module.params['physical_size_gb']
+        protection_scheme = self.module.params['protection_scheme']
+        compression_method = self.module.params['compression_method']
+        state = self.module.params['state']
+
+        result = dict(
+            changed=False,
+            storage_pool_details=None
+        )
+
+        sp_details = self.get(
+            storage_pool_id,
+            protection_domain_id,
+            storage_pool_name,
+        )
+
+        if state == 'absent':
+            if sp_details:
+                self.delete(sp_details['storage_pool_id'])
+                result['changed'] = True
+            self.module.exit_json(**result)
+            return
+
+        storage_pool = {}
+        if storage_pool_name is not None:
+            storage_pool['name'] = storage_pool_name
+        if protection_domain_id is not None:
+            storage_pool['protectionDomainId'] = protection_domain_id
+        if device_group_id is not None:
+            storage_pool['deviceGroupId'] = device_group_id
+        if cap_alert_high_threshold is not None:
+            storage_pool['capacityAlertHighThreshold'] = cap_alert_high_threshold
+        if cap_alert_critical_threshold is not None:
+            storage_pool['capacityAlertCriticalThreshold'] = cap_alert_critical_threshold
+        if over_provisioning_factor is not None:
+            storage_pool['overProvisioningFactor'] = over_provisioning_factor
+        if physical_size_gb is not None:
+            storage_pool['physicalSizeGB'] = physical_size_gb
+        if protection_scheme is not None:
+            storage_pool['protectionScheme'] = protection_scheme
+        if compression_method is not None:
+            storage_pool['compressionMethod'] = compression_method
+
+        if not sp_details:
+            result['storage_pool_details'] = self.create(storage_pool)
+            result['changed'] = True
+        else:
+            storage_pool['storage_pool_id'] = sp_details['id']
+            result['changed'], result['storage_pool_details'] = self.update(
+                storage_pool, sp_details)
+
+        self.module.exit_json(**result)
+
+
+def main():
+    """ Create PowerFlex storage pool object and perform action on it
+        based on user input from playbook"""
+    obj = PowerFlexStoragePoolV2()
+    obj.exec()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyPowerFlex==1.14.1
+PyPowerFlex==2.0.0

--- a/tests/unit/plugins/module_utils/libraries/powerflex_unit_base.py
+++ b/tests/unit/plugins/module_utils/libraries/powerflex_unit_base.py
@@ -6,6 +6,8 @@ from __future__ import (absolute_import, division, print_function)
 
 __metaclass__ = type
 import pytest
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
+    import utils
 # pylint: disable=unused-import
 from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.libraries import initial_mock
 from mock.mock import MagicMock
@@ -19,6 +21,8 @@ class PowerFlexUnitBase:
 
     @pytest.fixture
     def powerflex_module_mock(self, mocker, module_object):
+        utils.is_version_less = MagicMock(return_value=False)
+        utils.is_version_ge_or_eq = MagicMock(return_value=False)
         powerflex_module_mock = module_object()
         powerflex_module_mock.module = MagicMock()
         powerflex_module_mock.module.fail_json = fail_json


### PR DESCRIPTION
Compatibility check for modules

# Description
Modules with _v2 suffix are dedicated for PowerFlex EC(5.0). Add compatibility check for:
- Existing module + PowerFlex EC
- v2 module + PowerFlex 4 and below For the incompatible cases, prompt appropriate module in WARNING output of ansible-playbook and exit task

Since the version is bumped up to 3.0, remove
`pause` and `freeze` from `replication_consistency_group`

You may ignore the storagepool_v2.py and protection_domain_v2.py, as they are added to verify compatibility check and will be updated in coming weeks.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
