### PR TITLE
Add gen2 support warning

### DIFF
--- a/plugins/modules/replication_consistency_group.py
+++ b/plugins/modules/replication_consistency_group.py
@@ -475,6 +475,7 @@ from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.lib
 
 LOG = utils.get_logger('replication_consistency_group')
 
+
 @powerflex_compatibility(min_ver='3.6', max_ver='5.0')
 class PowerFlexReplicationConsistencyGroup(PowerFlexBase):
     """Class with replication consistency group operations"""

--- a/plugins/modules/replication_consistency_group.py
+++ b/plugins/modules/replication_consistency_group.py
@@ -468,38 +468,31 @@ replication_consistency_group_details:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
     import utils
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import powerflex_compatibility
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import PowerFlexBase
 
 LOG = utils.get_logger('replication_consistency_group')
 
-
-class PowerFlexReplicationConsistencyGroup(object):
+@powerflex_compatibility(min_ver='3.6', max_ver='5.0')
+class PowerFlexReplicationConsistencyGroup(PowerFlexBase):
     """Class with replication consistency group operations"""
 
     def __init__(self):
         """ Define all parameters required by this module"""
-        self.module_params = utils.get_powerflex_gateway_host_parameters()
-        self.module_params.update(get_powerflex_replication_consistency_group_parameters())
-
+        argument_spec = get_powerflex_replication_consistency_group_parameters()
         mut_ex_args = [['rcg_name', 'rcg_id'], ['protection_domain_id', 'protection_domain_name']]
-
         required_one_of_args = [['rcg_name', 'rcg_id']]
 
-        # initialize the Ansible module
-        self.module = AnsibleModule(
-            argument_spec=self.module_params,
-            supports_check_mode=True,
-            mutually_exclusive=mut_ex_args,
-            required_one_of=required_one_of_args)
-
-        utils.ensure_required_libs(self.module)
-
-        try:
-            self.powerflex_conn = utils.get_powerflex_gateway_host_connection(
-                self.module.params)
-            LOG.info("Got the PowerFlex system connection object instance")
-        except Exception as e:
-            LOG.error(str(e))
-            self.module.fail_json(msg=str(e))
+        ansible_module_params = {
+            'argument_spec': argument_spec,
+            'supports_check_mode': True,
+            'mutually_exclusive': mut_ex_args,
+            'required_one_of': required_one_of_args
+        }
+        super().__init__(AnsibleModule, ansible_module_params)
+        super().check_module_compatibility()
 
     def get_rcg(self, rcg_name=None, rcg_id=None):
         """Get rcg details

--- a/plugins/modules/replication_pair.py
+++ b/plugins/modules/replication_pair.py
@@ -380,6 +380,7 @@ from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.lib
 
 LOG = utils.get_logger('replication_pair')
 
+
 @powerflex_compatibility(min_ver='3.6', max_ver='5.0')
 class PowerFlexReplicationPair(PowerFlexBase):
     """Class with replication pair operations"""

--- a/plugins/modules/replication_pair.py
+++ b/plugins/modules/replication_pair.py
@@ -373,35 +373,29 @@ rcg_replication_pairs:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
     import utils
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import powerflex_compatibility
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import PowerFlexBase
 
 LOG = utils.get_logger('replication_pair')
 
-
-class PowerFlexReplicationPair(object):
+@powerflex_compatibility(min_ver='3.6', max_ver='5.0')
+class PowerFlexReplicationPair(PowerFlexBase):
     """Class with replication pair operations"""
 
     def __init__(self):
         """ Define all parameters required by this module"""
-        self.module_params = utils.get_powerflex_gateway_host_parameters()
-        self.module_params.update(get_powerflex_replication_pair_parameters())
-
+        argument_spec = get_powerflex_replication_pair_parameters()
         mut_ex_args = [['rcg_name', 'rcg_id'], ['pair_id', 'pair_name']]
 
-        # initialize the Ansible module
-        self.module = AnsibleModule(
-            argument_spec=self.module_params,
-            supports_check_mode=True,
-            mutually_exclusive=mut_ex_args)
-
-        utils.ensure_required_libs(self.module)
-
-        try:
-            self.powerflex_conn = utils.get_powerflex_gateway_host_connection(
-                self.module.params)
-            LOG.info("Got the PowerFlex system connection object instance")
-        except Exception as e:
-            LOG.error(str(e))
-            self.module.fail_json(msg=str(e))
+        ansible_module_params = {
+            'argument_spec': argument_spec,
+            'supports_check_mode': True,
+            'mutually_exclusive': mut_ex_args
+        }
+        super().__init__(AnsibleModule, ansible_module_params)
+        super().check_module_compatibility()
 
     def get_replication_pair(self, pair_name=None, pair_id=None):
         """Get replication pair details

--- a/plugins/modules/resource_group.py
+++ b/plugins/modules/resource_group.py
@@ -245,39 +245,35 @@ resource_group_details:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell \
     import utils
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import powerflex_compatibility
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import PowerFlexBase
 import json
 import copy
 
 LOG = utils.get_logger('resource_group')
 
 
-class PowerFlexResourceGroup:
+@powerflex_compatibility(min_ver='3.6', max_ver='5.0')
+class PowerFlexResourceGroup(PowerFlexBase):
     def __init__(self):
         """ Define all parameters required by this module"""
-        self.module_params = utils.get_powerflex_gateway_host_parameters()
-        self.module_params.update(get_powerflex_resource_group_parameters())
+        argument_spec = get_powerflex_resource_group_parameters()
         mut_ex_args = [['resource_group_name', 'resource_group_id'],
                        ['template_name', 'template_id'],
                        ['firmware_repository_id', 'firmware_repository_name']]
 
         required_one_of_args = [['resource_group_name', 'resource_group_id']]
 
-        # initialize the Ansible module
-        self.module = AnsibleModule(
-            argument_spec=self.module_params,
-            mutually_exclusive=mut_ex_args,
-            required_one_of=required_one_of_args,
-            supports_check_mode=True)
-
-        utils.ensure_required_libs(self.module)
-
-        try:
-            self.powerflex_conn = utils.get_powerflex_gateway_host_connection(
-                self.module.params)
-            LOG.info("Got the PowerFlex system connection object instance")
-        except Exception as e:
-            LOG.error(str(e))
-            self.module.fail_json(msg=str(e))
+        ansible_module_params = {
+            'argument_spec': argument_spec,
+            'supports_check_mode': True,
+            'mutually_exclusive': mut_ex_args,
+            'required_one_of': required_one_of_args
+        }
+        super().__init__(AnsibleModule, ansible_module_params)
+        super().check_module_compatibility()
 
     def get_service_template(self, template_id=None, template_name=None, for_deployment=True):
         """

--- a/plugins/modules/sds.py
+++ b/plugins/modules/sds.py
@@ -492,6 +492,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell\
     import utils
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
+    import powerflex_compatibility
+from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.powerflex_base \
     import PowerFlexBase
 from ansible_collections.dellemc.powerflex.plugins.module_utils.storage.dell.libraries.configuration \
     import Configuration
@@ -500,6 +502,7 @@ import copy
 LOG = utils.get_logger('sds')
 
 
+@powerflex_compatibility(min_ver='3.6', max_ver='5.0')
 class PowerFlexSDS(PowerFlexBase):
     """Class with SDS operations"""
 
@@ -525,6 +528,7 @@ class PowerFlexSDS(PowerFlexBase):
             'required_together': required_together_args
         }
         super().__init__(AnsibleModule, ansible_module_params)
+        super().check_module_compatibility()
 
         self.result = dict(
             changed=False,

--- a/tests/unit/plugins/modules/test_replication_consistency_group.py
+++ b/tests/unit/plugins/modules/test_replication_consistency_group.py
@@ -31,6 +31,8 @@ class TestPowerflexReplicationConsistencyGroup():
 
     @pytest.fixture
     def replication_consistency_group_module_mock(self):
+        utils.is_version_less = MagicMock(return_value=True)
+        utils.is_version_ge_or_eq = MagicMock(return_value=False)
         replication_consistency_group_module_mock = PowerFlexReplicationConsistencyGroup()
         replication_consistency_group_module_mock.module.check_mode = False
         return replication_consistency_group_module_mock

--- a/tests/unit/plugins/modules/test_replication_pair.py
+++ b/tests/unit/plugins/modules/test_replication_pair.py
@@ -33,6 +33,8 @@ class TestPowerflexReplicationPair:
 
     @pytest.fixture
     def replication_pair_module_mock(self):
+        utils.is_version_less = MagicMock(return_value=True)
+        utils.is_version_ge_or_eq = MagicMock(return_value=False)
         replication_pair_module_mock = PowerFlexReplicationPair()
         replication_pair_module_mock.get_rcg = MagicMock(return_value={"id": 123})
         replication_pair_module_mock.module.check_mode = False
@@ -40,6 +42,8 @@ class TestPowerflexReplicationPair:
 
     @pytest.fixture
     def replication_pair_mock(self):
+        utils.is_version_less = MagicMock(return_value=True)
+        utils.is_version_ge_or_eq = MagicMock(return_value=False)
         replication_pair_mock = PowerFlexReplicationPair()
         replication_pair_mock.module.check_mode = False
         replication_pair_mock.module.fail_json = fail_json


### PR DESCRIPTION
# Description
Add gen2 support warning for unsupported modules


# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
- [x] Manual FT
