### PR TITLE
feat(storagepool_v2): add num_data_slices for flexible erasure coding

### DIFF
--- a/changelogs/fragments/feat-storagepool-v2-num-data-slices.yml
+++ b/changelogs/fragments/feat-storagepool-v2-num-data-slices.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - storagepool_v2 - added the I(num_data_slices) parameter to support flexible
+    erasure-coding data-slice configurations (for example 4+2) on Gen2 storage
+    pools, beyond the fixed TwoPlusTwo and EightPlusTwo presets. When omitted,
+    the data-slice count continues to be derived from I(protection_scheme),
+    preserving backward compatibility.

--- a/docs/modules/storagepool_v2.rst
+++ b/docs/modules/storagepool_v2.rst
@@ -107,6 +107,16 @@ Parameters
     The protection scheme.
 
 
+  num_data_slices (False, int, None)
+    The number of data slices for erasure coding on a Gen2 storage pool.
+
+    When specified, this value is used directly and overrides the data-slice count that would otherwise be derived from :emphasis:`protection\_scheme`.
+
+    Must be a positive integer. Applies only during storage pool creation.
+
+    Enables custom protection schemes (for example 4+2) beyond the fixed TwoPlusTwo and EightPlusTwo presets.
+
+
   state (True, str, None)
     The state of the storage pool. Can be 'present' or 'absent'.
 

--- a/playbooks/modules/storagepool_v2.yml
+++ b/playbooks/modules/storagepool_v2.yml
@@ -4,9 +4,14 @@
   connection: local
   gather_facts: false
   vars:
-    hostname: "x.x.x.x"
-    username: "admin"
-    password: "Password"
+    # Non-secret placeholders kept in version control. Supply real values at
+    # runtime via --extra-vars, e.g.:
+    #   ansible-playbook storagepool_v2.yml --extra-vars \
+    #     '{"hostname":"...","port":443,"validate_certs":false,"username":"...","password":"..."}'
+    hostname: "<your_powerflex_host>"
+    port: 443
+    username: "<your_powerflex_username>"
+    password: "<your_powerflex_password>"
     validate_certs: false
 
   tasks:
@@ -20,6 +25,20 @@
         protection_domain_name: "{{ domain1 }}"
         device_group_name: "{{ dg_name }}"
         protection_scheme: "TwoPlusTwo"
+        compression_method: "Normal"
+        use_all_available_capacity: true
+        state: "present"
+
+    - name: Create storagepool with a custom number of data slices (e.g. 4+2)
+      dellemc.powerflex.storagepool_v2:
+        hostname: "{{ hostname }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        storage_pool_name: "{{ sp_name }}"
+        protection_domain_name: "{{ domain1 }}"
+        device_group_name: "{{ dg_name }}"
+        num_data_slices: 4
         compression_method: "Normal"
         use_all_available_capacity: true
         state: "present"

--- a/playbooks/modules/storagepool_v2.yml
+++ b/playbooks/modules/storagepool_v2.yml
@@ -7,9 +7,9 @@
     # Non-secret placeholders kept in version control. Supply real values at
     # runtime via --extra-vars, e.g.:
     #   ansible-playbook storagepool_v2.yml --extra-vars \
-    #     '{"hostname":"...","port":443,"validate_certs":false,"username":"...","password":"..."}'
+    #     '{"hostname":"...","gateway_port":443,"validate_certs":false,"username":"...","password":"..."}'
     hostname: "<your_powerflex_host>"
-    port: 443
+    gateway_port: 443
     username: "<your_powerflex_username>"
     password: "<your_powerflex_password>"
     validate_certs: false

--- a/plugins/modules/storagepool_v2.py
+++ b/plugins/modules/storagepool_v2.py
@@ -117,6 +117,16 @@ options:
     required: false
     type: str
     choices: ['TwoPlusTwo', 'EightPlusTwo']
+  num_data_slices:
+    description:
+      - The number of data slices for erasure coding on a Gen2 storage pool.
+      - When specified, this value is used directly and overrides the data-slice
+        count that would otherwise be derived from I(protection_scheme).
+      - Must be a positive integer. Applies only during storage pool creation.
+      - Enables custom protection schemes (for example 4+2) beyond the fixed
+        TwoPlusTwo and EightPlusTwo presets.
+    required: false
+    type: int
   state:
     description:
       - The state of the storage pool. Can be 'present' or 'absent'.
@@ -164,6 +174,20 @@ EXAMPLES = r'''
     over_provisioning_factor: 2
     physical_size_gb: 100
     protection_scheme: TwoPlusTwo
+    state: "present"
+
+- name: Create a new Storage pool with a custom 4+2 protection scheme
+  dellemc.powerflex.storagepool_v2:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    storage_pool_name: "{{ pool_name }}"
+    protection_domain_name: "{{ protection_domain_name }}"
+    device_group_name: "{{ device_group_name }}"
+    num_data_slices: 4
+    compression_method: Normal
+    use_all_available_capacity: true
     state: "present"
 
 - name: Modify a Storage pool by name
@@ -497,6 +521,7 @@ class PowerFlexStoragePoolV2(PowerFlexBase):
             use_all_available_capacity=dict(type='bool'),
             protection_scheme=dict(type='str', choices=[
                 'TwoPlusTwo', 'EightPlusTwo']),
+            num_data_slices=dict(type='int'),
             state=dict(required=True, type='str',
                        choices=['present', 'absent']),
         )
@@ -611,7 +636,9 @@ class PowerFlexStoragePoolV2(PowerFlexBase):
 
             self.powerflex_conn.storage_pool.check_update_params(storage_pool, current_storage_pool)
             if self.module.check_mode:
-                storage_pool["name"] = storage_pool.get("storage_pool_new_name", storage_pool["name"])
+                new_name = storage_pool.get("storage_pool_new_name")
+                if new_name:
+                    storage_pool["name"] = new_name
                 storage_pool.pop("storage_pool_new_name", None)
                 need_update, changes = self.powerflex_conn.storage_pool.need_update(storage_pool, current_storage_pool)
                 if storage_pool.get("useAllAvailableCapacity"):
@@ -692,12 +719,17 @@ class PowerFlexStoragePoolV2(PowerFlexBase):
         use_all_available_capacity = self.module.params['use_all_available_capacity']
         protection_scheme = self.module.params['protection_scheme']
         compression_method = self.module.params['compression_method']
+        num_data_slices = self.module.params.get('num_data_slices')
         state = self.module.params['state']
 
         result = dict(
             changed=False,
             storage_pool_details=None
         )
+
+        if num_data_slices is not None and num_data_slices <= 0:
+            self.module.fail_json(
+                msg="num_data_slices must be a positive integer.")
 
         if storage_pool_name and not (protection_domain_id or protection_domain_name):
             self.module.fail_json(
@@ -740,6 +772,7 @@ class PowerFlexStoragePoolV2(PowerFlexBase):
             'useAllAvailableCapacity': use_all_available_capacity,
             'protectionScheme': protection_scheme,
             'compressionMethod': compression_method,
+            'numDataSlices': num_data_slices,
         }
         storage_pool = {k: v for k, v in storage_pool.items() if v is not None}
 

--- a/tests/unit/plugins/module_utils/mock_storagepool_api_v2.py
+++ b/tests/unit/plugins/module_utils/mock_storagepool_api_v2.py
@@ -108,6 +108,8 @@ class MockStoragePoolV2Api:
         "rawSizeGB": 8192,
         "wrcDeviceGroupId": "39a898be00000000",
         "rebalanceEnabled": None,
+        "numDataSlices": 2,
+        "numProtectionSlices": 2,
         "id": "5dac1b0300000000",
     }
 
@@ -351,6 +353,7 @@ class MockStoragePoolV2Api:
         "device_group_exception": "Failed to get device group",
         "mismatch_device_group_id_exception": "Entered device group id does not match",
         "mismatch_device_group_name_exception": "Entered device group name does not match",
+        "invalid_num_data_slices": "num_data_slices must be a positive integer",
     }
 
     @staticmethod

--- a/tests/unit/plugins/modules/test_storagepool_v2.py
+++ b/tests/unit/plugins/modules/test_storagepool_v2.py
@@ -679,3 +679,59 @@ class TestPowerflexStoragePoolV2(PowerFlexUnitBase):
             powerflex_module_mock.perform_module_operation()
             assert powerflex_module_mock.module.exit_json.call_args[1]['changed'] is True
             powerflex_module_mock.powerflex_conn.storage_pool.create.assert_not_called()
+
+    def test_update_validation_use_all_capacity_with_physical_size(self, powerflex_module_mock):
+        """M-007: update fails when use_all_available_capacity=True and physical_size_gb is specified."""
+        self.set_module_params(
+            powerflex_module_mock,
+            self.get_module_args,
+            {
+                "storage_pool_name": "test_pool",
+                "protection_domain_name": "test_pd_1",
+                "device_group_name": "test_dg_1",
+                "use_all_available_capacity": True,
+                "physical_size_gb": 4096,
+                "state": "present"
+            })
+        powerflex_module_mock.powerflex_conn.storage_pool.get_by_name = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL)
+        powerflex_module_mock.powerflex_conn.storage_pool.update = MagicMock(
+            return_value=(False, MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL))
+        powerflex_module_mock.powerflex_conn.protection_domain.get = MagicMock(
+            return_value=MockStoragePoolV2Api.PROTECTION_DOMAIN['protection_domain'])
+        powerflex_module_mock.powerflex_conn.device_group.get = MagicMock(
+            return_value=MockStoragePoolV2Api.DEVICE_GROUP['device_group'])
+        powerflex_module_mock.powerflex_conn.utility.query_metrics = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_STATISTICS
+        )
+        with pytest.raises(FailJsonException) as exc:
+            powerflex_module_mock.perform_module_operation()
+        assert "physical_size_gb must not be specified" in exc.value.message
+
+    def test_check_mode_update_with_storage_pool_new_name(self, powerflex_module_mock):
+        """M-008: check mode update with storage_pool_new_name handles the name change correctly."""
+        powerflex_module_mock.powerflex_conn.storage_pool.get_by_name = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL)
+        powerflex_module_mock.powerflex_conn.protection_domain.get = MagicMock(
+            return_value=MockStoragePoolV2Api.PROTECTION_DOMAIN['protection_domain'])
+        powerflex_module_mock.powerflex_conn.device_group.get = MagicMock(
+            return_value=MockStoragePoolV2Api.DEVICE_GROUP['device_group'])
+        powerflex_module_mock.powerflex_conn.storage_pool.need_update = MagicMock(
+            return_value=(True, {"name": "new_pool_name"})
+        )
+        powerflex_module_mock.powerflex_conn.utility.query_metrics = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_STATISTICS
+        )
+        with patch.object(powerflex_module_mock.module, 'check_mode', True):
+            self.set_module_params(
+                powerflex_module_mock,
+                self.get_module_args,
+                {
+                    "storage_pool_name": "test_pool",
+                    "storage_pool_new_name": "new_pool_name",
+                    "protection_domain_name": "test_pd_1",
+                    "state": "present"
+                })
+            powerflex_module_mock.perform_module_operation()
+            assert powerflex_module_mock.module.exit_json.call_args[1]['changed'] is True
+            powerflex_module_mock.powerflex_conn.storage_pool.update.assert_not_called()

--- a/tests/unit/plugins/modules/test_storagepool_v2.py
+++ b/tests/unit/plugins/modules/test_storagepool_v2.py
@@ -704,9 +704,11 @@ class TestPowerflexStoragePoolV2(PowerFlexUnitBase):
         powerflex_module_mock.powerflex_conn.utility.query_metrics = MagicMock(
             return_value=MockStoragePoolV2Api.STORAGE_POOL_STATISTICS
         )
-        with pytest.raises(FailJsonException) as exc:
-            powerflex_module_mock.perform_module_operation()
-        assert "physical_size_gb must not be specified" in exc.value.message
+        self.capture_fail_json_call(
+            MockStoragePoolV2Api.get_exception_response(
+                'physical_size_gb_should_not_specify'),
+            module_mock=powerflex_module_mock,
+            invoke_perform_module=True)
 
     def test_check_mode_update_with_storage_pool_new_name(self, powerflex_module_mock):
         """M-008: check mode update with storage_pool_new_name handles the name change correctly."""
@@ -722,7 +724,7 @@ class TestPowerflexStoragePoolV2(PowerFlexUnitBase):
         powerflex_module_mock.powerflex_conn.utility.query_metrics = MagicMock(
             return_value=MockStoragePoolV2Api.STORAGE_POOL_STATISTICS
         )
-        with patch.object(powerflex_module_mock.module, 'check_mode', True):
+        with patch.object(powerflex_module_mock.module, 'check_mode', return_value=True):
             self.set_module_params(
                 powerflex_module_mock,
                 self.get_module_args,

--- a/tests/unit/plugins/modules/test_storagepool_v2.py
+++ b/tests/unit/plugins/modules/test_storagepool_v2.py
@@ -15,8 +15,11 @@ from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_
     import MockApiException
 from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.libraries.powerflex_unit_base \
     import PowerFlexUnitBase
+from ansible_collections.dellemc.powerflex.plugins.modules import storagepool_v2 as storagepool_v2_module
 from ansible_collections.dellemc.powerflex.plugins.modules.storagepool_v2 \
     import PowerFlexStoragePoolV2
+from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.libraries.fail_json \
+    import FailJsonException
 from ansible_collections.dellemc.powerflex.tests.unit.plugins.module_utils.mock_storagepool_api_v2 import \
     MockStoragePoolV2Api
 
@@ -560,3 +563,119 @@ class TestPowerflexStoragePoolV2(PowerFlexUnitBase):
                     'delete_storage_pool'),
                 module_mock=powerflex_module_mock,
                 invoke_perform_module=True)
+
+    # ------------------------------------------------------------------
+    # Flexible data slices (FEAT-23070) — added by TDD Writer (Stage 07)
+    # ------------------------------------------------------------------
+
+    def _set_create_mocks(self, powerflex_module_mock, existing=None):
+        powerflex_module_mock.powerflex_conn.storage_pool.get_by_name = MagicMock(
+            return_value=existing)
+        powerflex_module_mock.powerflex_conn.storage_pool.create = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL)
+        powerflex_module_mock.powerflex_conn.storage_pool.update = MagicMock(
+            return_value=(False, MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL))
+        powerflex_module_mock.powerflex_conn.protection_domain.get = MagicMock(
+            return_value=MockStoragePoolV2Api.PROTECTION_DOMAIN['protection_domain'])
+        powerflex_module_mock.powerflex_conn.device_group.get = MagicMock(
+            return_value=MockStoragePoolV2Api.DEVICE_GROUP['device_group'])
+        powerflex_module_mock.powerflex_conn.utility.query_metrics = MagicMock(
+            return_value=MockStoragePoolV2Api.STORAGE_POOL_STATISTICS)
+
+    def test_num_data_slices_documented(self, powerflex_module_mock):
+        """M-001: the num_data_slices parameter is documented on the module."""
+        assert "num_data_slices" in storagepool_v2_module.DOCUMENTATION
+
+    def test_create_with_num_data_slices(self, powerflex_module_mock):
+        """M-002: num_data_slices is forwarded to the SDK create payload."""
+        self.set_module_params(
+            powerflex_module_mock,
+            self.get_module_args,
+            {
+                "storage_pool_name": "test_pool",
+                "protection_domain_name": "test_pd_1",
+                "device_group_name": "test_dg_1",
+                "num_data_slices": 4,
+                "compression_method": "Normal",
+                "use_all_available_capacity": True,
+                "state": "present"
+            })
+        self._set_create_mocks(powerflex_module_mock, existing=None)
+        powerflex_module_mock.perform_module_operation()
+        called_sp = powerflex_module_mock.powerflex_conn.storage_pool.create.call_args[0][0]
+        assert called_sp.get("numDataSlices") == 4
+
+    def test_create_protection_scheme_backward_compat(self, powerflex_module_mock):
+        """M-003: protection_scheme-only create does not inject numDataSlices."""
+        self.set_module_params(
+            powerflex_module_mock,
+            self.get_module_args,
+            {
+                "storage_pool_name": "test_pool",
+                "protection_domain_name": "test_pd_1",
+                "device_group_name": "test_dg_1",
+                "protection_scheme": "EightPlusTwo",
+                "use_all_available_capacity": True,
+                "state": "present"
+            })
+        self._set_create_mocks(powerflex_module_mock, existing=None)
+        powerflex_module_mock.perform_module_operation()
+        called_sp = powerflex_module_mock.powerflex_conn.storage_pool.create.call_args[0][0]
+        assert "numDataSlices" not in called_sp
+        assert called_sp.get("protectionScheme") == "EightPlusTwo"
+
+    def test_create_invalid_num_data_slices(self, powerflex_module_mock):
+        """M-004: a non-positive num_data_slices fails with an actionable error."""
+        self.set_module_params(
+            powerflex_module_mock,
+            self.get_module_args,
+            {
+                "storage_pool_name": "test_pool",
+                "protection_domain_name": "test_pd_1",
+                "device_group_name": "test_dg_1",
+                "num_data_slices": 0,
+                "use_all_available_capacity": True,
+                "state": "present"
+            })
+        self._set_create_mocks(powerflex_module_mock, existing=None)
+        with pytest.raises(FailJsonException) as exc:
+            powerflex_module_mock.perform_module_operation()
+        assert "num_data_slices must be a positive integer" in exc.value.message
+
+    def test_num_data_slices_ignored_on_update(self, powerflex_module_mock):
+        """M-005: num_data_slices on an existing pool is ignored (non-updatable)."""
+        self.set_module_params(
+            powerflex_module_mock,
+            self.get_module_args,
+            {
+                "storage_pool_name": "test_pool",
+                "protection_domain_name": "test_pd_1",
+                "device_group_name": "test_dg_1",
+                "num_data_slices": 4,
+                "state": "present"
+            })
+        self._set_create_mocks(
+            powerflex_module_mock,
+            existing=MockStoragePoolV2Api.STORAGE_POOL_GET_DETAIL)
+        powerflex_module_mock.perform_module_operation()
+        powerflex_module_mock.powerflex_conn.storage_pool.update.assert_called()
+        powerflex_module_mock.powerflex_conn.storage_pool.create.assert_not_called()
+
+    def test_check_mode_with_num_data_slices(self, powerflex_module_mock):
+        """M-006: check mode create with num_data_slices does not call SDK create."""
+        self._set_create_mocks(powerflex_module_mock, existing=None)
+        with patch.object(powerflex_module_mock.module, 'check_mode', True):
+            self.set_module_params(
+                powerflex_module_mock,
+                self.get_module_args,
+                {
+                    "storage_pool_name": "test_pool",
+                    "protection_domain_name": "test_pd_1",
+                    "device_group_name": "test_dg_1",
+                    "num_data_slices": 4,
+                    "use_all_available_capacity": True,
+                    "state": "present"
+                })
+            powerflex_module_mock.perform_module_operation()
+            assert powerflex_module_mock.module.exit_json.call_args[1]['changed'] is True
+            powerflex_module_mock.powerflex_conn.storage_pool.create.assert_not_called()


### PR DESCRIPTION
Add the num_data_slices (int) parameter to the storagepool_v2 module so Gen2 storage pools can be created with custom erasure-coding schemes (e.g. 4+2) beyond the fixed TwoPlusTwo/EightPlusTwo presets. The value is validated (positive integer) and passed through to the PyPowerFlex SDK create payload; protection_scheme remains supported for backward compatibility. Also fix a pre-existing check-mode KeyError on update-by-id discovered during live playbook validation.

Adds DOCUMENTATION, EXAMPLES, RST docs, an example playbook task, a changelog fragment, and unit tests (M-001..M-006).

FEAT-23070

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [ ] I have performed Ansible Sanity test using --docker default
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
