### PR TITLE
Release 3.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,28 @@ Dellemc.PowerFlex Change Logs
 
 .. contents:: Topics
 
+v3.1.0
+======
+
+Release Summary
+---------------
+
+This release adds the device_group and thin_clone modules for PowerFlex Gen2, along with CI and code quality improvements.
+
+Minor Changes
+-------------
+
+- Added the ``device_group`` module to manage existing PowerFlex Gen2 device groups. The module supports getting device group details by name or ID, renaming a device group, updating spare node and spare device counts, and querying usable capacity. Device group creation and deletion are not supported.
+- Added the ``thin_clone`` module to create thin clones from a source volume or a read-only snapshot on PowerFlex 5.x Gen2 systems. This module is creation-only; ongoing management of the resulting thin clone is handled by the ``volume`` module.
+- Fixed sanity and lint issues in info_v2 module.
+- Updated GitHub Actions workflow for improved CI stability.
+
+New Modules
+-----------
+
+- dellemc.powerflex.device_group - Manage Device Groups on Dell PowerFlex Gen2
+- dellemc.powerflex.thin_clone - Create Thin Clones on Dell PowerFlex 5.x (Gen2)
+
 v3.0.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The capabilities of the Ansible modules are managing SDCs, volumes, snapshots, s
 
 | **Ansible Modules** | **PowerFlex/VxFlex OS Version** | **SDK version** | **Python version** | **Ansible**              |
 |---------------------|-----------------------|-------|--------------------|--------------------------|
-| v3.0.0 |4.8 <br> 4.6 <br> 5.0 <br> APEX Block Storage for Mircrosoft Azure <br> APEX Block Storage for AWS | 2.0.0 | 3.13.x <br> 3.14.x | 2.18 <br> 2.19 <br> 2.20 |
+| v3.1.0 |4.8 <br> 4.6 <br> 5.0 <br> APEX Block Storage for Mircrosoft Azure <br> APEX Block Storage for AWS | 2.0.0 | 3.13.x <br> 3.14.x | 2.18 <br> 2.19 <br> 2.20 |
 
   * Please follow PyPowerFlex installation instructions on [PyPowerFlex Documentation](https://github.com/dell/python-powerflex)
 
@@ -89,6 +89,8 @@ The modules are written in such a way that all requests are idempotent and hence
   * [Replication Pair Module](https://github.com/dell/ansible-powerflex/blob/main/docs/modules/replication_pair.rst)
   * [Snapshot Policy Module](https://github.com/dell/ansible-powerflex/blob/main/docs/modules/snapshot_policy.rst)
   * [Fault Sets Module](https://github.com/dell/ansible-powerflex/blob/main/docs/modules/fault_set.rst)
+  * [Device Group Module](https://github.com/dell/ansible-powerflex/blob/main/docs/modules/device_group.rst)
+  * [Thin Clone Module](https://github.com/dell/ansible-powerflex/blob/main/docs/modules/thin_clone.rst)
 
 
 ## Support

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -228,3 +228,28 @@ releases:
         name: volume_v2
         namespace: ''
     release_date: '2025-09-30'
+
+  3.1.0:
+    changes:
+      minor_changes:
+        - Added the ``device_group`` module to manage existing PowerFlex Gen2 device
+          groups. The module supports getting device group details by name or ID,
+          renaming a device group, updating spare node and spare device counts, and
+          querying usable capacity. Device group creation and deletion are not
+          supported.
+        - Added the ``thin_clone`` module to create thin clones from a source volume
+          or a read-only snapshot on PowerFlex 5.x Gen2 systems. This module is
+          creation-only; ongoing management of the resulting thin clone is handled
+          by the ``volume`` module.
+        - Fixed sanity and lint issues in info_v2 module.
+        - Updated GitHub Actions workflow for improved CI stability.
+      release_summary: This release adds the device_group and thin_clone modules
+        for PowerFlex Gen2, along with CI and code quality improvements.
+    modules:
+      - description: Manage Device Groups on Dell PowerFlex Gen2
+        name: device_group
+        namespace: ''
+      - description: Create Thin Clones on Dell PowerFlex 5.x (Gen2)
+        name: thin_clone
+        namespace: ''
+    release_date: '2026-06-23'

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -31,7 +31,7 @@
 
   * Download the latest tar build from any of the available distribution channel [Ansible Galaxy](https://galaxy.ansible.com/dellemc/powerflex) /[Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dellemc/powerflex) and use this command to install the collection anywhere in your system:
  
-        ansible-galaxy collection install dellemc-powerflex-3.0.0.tar.gz -p <install_path>
+        ansible-galaxy collection install dellemc-powerflex-3.1.0.tar.gz -p <install_path>
 
   * Set the environment variable:
   

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -1,6 +1,6 @@
 **Ansible Modules for Dell Technologies PowerFlex** 
 =========================================
-### Release notes 3.0.0
+### Release notes 3.1.0
 
 >   © 2025 Dell Inc. or its subsidiaries. All rights reserved. Dell
 >   and other trademarks are trademarks of Dell Inc. or its
@@ -28,6 +28,7 @@ Table 1. Revision history
 
 | Revision | Date            | Description                                                 |
 |----------|-----------------|-------------------------------------------------------------|
+| 04       | Jun 2026        | Current release of Ansible Modules for Dell PowerFlex 3.1.0 |
 | 03       | Sep 2025        | Current release of Ansible Modules for Dell PowerFlex 3.0.0 |
 | 02       | June 2025       | Current release of Ansible Modules for Dell PowerFlex 2.6.1 |
 | 01       | Dec 2024        | Current release of Ansible Modules for Dell PowerFlex 2.6.0 |
@@ -48,11 +49,20 @@ New features and enhancements
 Note: In this context, PowerFlex Gen1 refers to PowerFlex versions < 5.0.0, and PowerFlex Gen2
 refers to PowerFlex versions ≥ 5.0.0.
 
-This release introduces extended support for Dell PowerFlex Gen2 by adding compatibility for
+This release adds the following new modules for PowerFlex Gen2:
+
+- **device_group** - Manage existing PowerFlex Gen2 device groups. The module supports getting device group details by name or ID, renaming a device group, updating spare node and spare device counts, and querying usable capacity. Device group creation and deletion are not supported.
+- **thin_clone** - Create thin clones from a source volume or a read-only snapshot on PowerFlex 5.x Gen2 systems. This module is creation-only; ongoing management of the resulting thin clone is handled by the volume module.
+
+This release also includes code quality improvements:
+- Fixed sanity and lint issues in info_v2 module
+- Updated GitHub Actions workflow for improved CI stability
+
+Previous release (3.0.0) introduced extended support for Dell PowerFlex Gen2 by adding compatibility for
 modules including mdm_cluster, nvme_host, sdc, sdt, and snapshot_policy, as well as
 roles such as activemq, lia, mdm, and tb.
 
-This release also includes new Gen2-specific modules — device_v2, info_v2, protection_domain_v2,
+The 3.0.0 release also included new Gen2-specific modules — device_v2, info_v2, protection_domain_v2,
 snapshot_v2, storagepool_v2, and volume_v2 — which replace their original Gen1 counterparts for Gen2 environments.
 
 Additionally, the modules fault_set, replication_consistency_group, replication_pair, resource_group,

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,7 +14,7 @@ name: powerflex
 
 # The version of the collection.
 # Must be compatible with semantic versioning
-version: 3.0.0
+version: 3.1.0
 
 # The path to the Markdown (.md) readme file.
 # This path is relative to the root of the collection.


### PR DESCRIPTION
Release 3.1.0

## New Modules
- **device_group** - Manage Device Groups on Dell PowerFlex Gen2
- **thin_clone** - Create Thin Clones on Dell PowerFlex 5.x (Gen2)

## Minor Changes
- Fixed sanity and lint issues in info_v2 module
- Updated GitHub Actions workflow for improved CI stability

## Documentation Updates
- Updated galaxy.yml version to 3.1.0
- Updated CHANGELOG.rst with v3.1.0 section
- Updated README.md with new modules and version
- Updated changelog.yaml with v3.1.0 entry